### PR TITLE
문서: v1.1 엄격 Must/Should 재분류 + 신규 SPEC 5종 (REG/SEC/IOP/OPS/P3-AI)

### DIFF
--- a/.moai/project/product.md
+++ b/.moai/project/product.md
@@ -1,15 +1,19 @@
-# Product Overview: X-ray Image Processing Engine
+# 제품 개요: X-ray Image Processing Engine (XPE) (v2.0)
 
-## Product Identity
+**Version**: 2.0.0 | **Updated**: 2026-04-17
+**Changes from v1.0**: 2024-2026 규제 환경 반영 (FDA PCCP/AI-DSF/Transparency, EU AI Act, ISO 42001, IEC 81001-5-1), Must/Should/Could 전략 명시, 신규 SPEC 4종(REG/SEC/IOP/OPS) 참조. See `.moai/project/trend-survey-2026.md`.
 
-- **Name**: X-ray Image Processing Engine
-- **Repository**: https://github.com/holee9/image-processing
-- **Domain**: Medical Device Software (X-ray Flat Panel Detector)
-- **Regulatory**: IEC 62304 Class B/C, FDA 21 CFR 820.30, EU MDR 2017/745
+## 제품 정체성
 
-## Purpose
+- **이름**: X-ray Image Processing Engine (XPE)
+- **저장소**: https://github.com/holee9/image-processing
+- **분야**: 의료 기기 소프트웨어 (X-ray Flat Panel Detector)
+- **규제**: IEC 62304 Class B/C, FDA 21 CFR 820.30, EU MDR 2017/745, **FDA §524B Cyber Device (2025-06 Final)**, **FDA PCCP AI-DSF (2024-12 Final)**, **FDA AI-DSF Lifecycle (2025-01 Draft)**, **EU Regulation 2024/1689 AI Act (2027-08 전면 발효)**, **ISO/IEC 42001:2023 AIMS**, **IEC 81001-5-1:2021 Secure SW Lifecycle**, **QMSR 2026-02-02 발효**
+- **개발 상태**: 활성 개발 중 (Active Product Development)
 
-X-ray Flat Panel Detector(FPD)에서 획득한 Raw 영상 데이터를 진단 가능한 의료 영상으로 변환하는 영상처리 엔진. Detector raw data의 보정(Pre-Processing)부터 영상 향상 및 DICOM 표시(Post-Processing)까지 전체 파이프라인을 커버한다.
+## 목적
+
+X-ray Flat Panel Detector(FPD)에서 획득한 Raw 영상 데이터를 진단 가능한 의료 영상으로 변환하는 영상처리 엔진. Detector raw data의 보정(Pre-Processing)부터 영상 향상 및 DICOM 표시(Post-Processing)까지 전체 파이프라인을 커버하며, 의료 기기 규정 인증을 목표로 개발 중입니다.
 
 ## Product Components
 
@@ -62,11 +66,62 @@ X-ray Flat Panel Detector(FPD)에서 획득한 Raw 영상 데이터를 진단 �
 
 ## Must-Have vs Differentiator Strategy
 
-출처: `docs/xray_fpd_tech_classification_final.md` (v2.0, 2026-04-13)
+출처: `docs/xray_fpd_tech_classification_final.md` (v2.0, 2026-04-13), **확장 출처**: `.moai/project/trend-survey-2026.md` (v1.0, 2026-04-17)
 
 - **필수 (Must-Have)**: 미구현 시 IEC/FDA 규제 인증 불가. Pre-Processing 전체(PRE-01~09), Support(SUP-01~05), Post-Processing 기반(POST-01~04, POST-07 기본, POST-12) 해당.
 - **차별화 (Differentiator)**: Phase 2/3에서 경쟁 우위 확보. PRE-04 NLCSC(14-50x), PRE-06 ML(14.2x), POST-05 MFP, POST-09 Bone Suppression, POST-11 Virtual Grid.
 - **HW/SW 경계**: PRE-01은 FPGA 전담(HW팀). PRE-02,03,06,08,09는 SW-first 후 FPGA 이관 가능 설계. PRE-07은 SW-first 후 MCU 이관 가능 설계. PRE-04,05는 SW-only.
+
+### Must/Should/Could 3-Tier 전략 (v2.1 Strict)
+
+**v2.1 변경**: 엄격 재분류 (2026-04-17). Must 27→12. "반드시 출시 블로커 또는 법적 의무"만 Must. 프로젝트 관례·자발적 표준은 Should.
+
+| Tier | 항목 수 (v2.1) | 의미 | 문서 |
+|:----:|:------:|------|------|
+| **Must** | **12** (was 27) | 법률 의무 OR 시장 진입 블로커 OR IEC 62304 강제 조항 | 신규 SPEC 4종의 core 부분 + IEC 62304 |
+| **Should** | **35** (was 19) | 강력 권장 · 경쟁력 · Phase 연결 조건부 Must | Phase 2/3 및 AI 배포 결정 시 승격 |
+| **Could** | 10 | 미래 옵션·연구 모드 | Phase 4 Research Track |
+
+**v2.1 엄격 판정 기준**: "이것이 없으면 출시 불가 또는 법적 거절?" → YES만 Must
+
+### Must 12항목 (v2.1 엄격)
+
+| ID | 항목 | 블로커 근거 |
+|:--:|------|------------|
+| M-01 | IEC 62304 Class B | 의료기기 SW 법적 분류 증명 |
+| M-02 | EU MDR 2017/745 | EU 시장 진입 법률 |
+| M-03 | FDA 21 CFR 820.30 + QMSR 2026 | US 시장 진입 법률 |
+| M-04 | FDA §524B Cyber Device | 2023 법률 (DICOM 네트워크 = 강제 cyber device) |
+| M-05 | SBOM (SPDX 3.0/CycloneDX 1.6) | §524B 법적 필수 구성요소 |
+| M-06 | Vulnerability Management | §524B 판매 후 법적 의무 |
+| M-07 | Basic Input Validation | 기본 방어 + IEC 62304 결합 |
+| M-08 | DICOM 3.0 Core | 병원 PACS 통합 실질적 필수 |
+| M-09 | DICOM Conformance Statement | 병원 구매 실사 법적 증빙 |
+| M-10 | Post-Market Surveillance | EU MDR Article 83 법률 |
+| M-11 | Characterization Tests | IEC 62304 §5.4.1 강제 조항 |
+| M-12 | Trackability (RTM, commits) | IEC 62304 §5.4.1 강제 조항 |
+
+### Should 35항목 (v2.1 확장, 조건부 Must 승격)
+
+- **Regulatory Should 8**: FDA PCCP, AI-DSF Lifecycle Draft, Transparency, IMDRF GMLP, EU AI Act, ISO 42001, 기존 S-REG-01~02 — **Phase 3 AI 배포 시 Must 승격**
+- **Cybersecurity Should 5**: IEC 81001-5-1 (자발적), SLSA L3, Threat Modeling, SBOM Continuous, CVD — **SBOM/L3는 Phase 2 Must 승격 권고**
+- **Interoperability Should 5**: DICOMweb (Phase 2+), FHIR R5 (Phase 2-3+), IHE AIR/AIRA (Phase 3+), IHE Baseline (통합 편의), DICOM SR for AI — **Phase 연결**
+- **AI Should 8**: SSL Denoising, Diffusion Priors, Conformal UQ, XAI, ONNX 1.20+, ML Defect, Bone Suppression, AI Collimation — **Phase 3 진입 시**
+- **Operations Should 5**: Drift Detection, OpenTelemetry, VEX, Reject-Analysis, Reproducible Builds — **운영 성숙도 향상**
+- **Quality/Architecture Should 4**: TRUST 5, Reference+SIMD Parity, MX Tag System, Anti-Spaghetti — **프로젝트 품질 기반 (v2.0 Must → v2.1 Should)**
+
+### Could 10항목 (Phase 4+)
+
+MedSAM Foundation Model, Federated Learning, GPU Production Path, Rust Safety Module, PQC, FHIRcast, WebAssembly, Continuous Learning, NIST AI RMF Full Adoption, Generative AI
+
+### 조건부 Must 승격 규칙 (v2.1 신규)
+
+- Phase 3 AI-DSF 배포 승인 → S-REG-03~07, S-AI-06~08 항목 Must 승격
+- EU 시장 + AI 판매 결정 → S-REG-07 (EU AI Act) Must 승격
+- Connectathon 참여 결정 → S-IOP-05 (IHE Baseline) Must 승격
+- SLSA L3 인증 결정 → S-SEC-01 Must 승격
+
+상세: `.moai/project/trend-survey-2026.md` v1.1 §1-§4
 
 ## Architecture Principle
 
@@ -76,14 +131,68 @@ X-ray Flat Panel Detector(FPD)에서 획득한 Raw 영상 데이터를 진단 �
 - Layer 1-G: GSVG (독립 IEC 62304 패키지, xpe_common 비의존)
 - Layer 2: C# GUI Orchestrator (P/Invoke로 모든 DLL 호출)
 
-## Target Users
+## 대상 사용자
 
-- 영상처리 엔지니어: 알고리즘 개발 및 튜닝
-- QA 엔지니어: IEC 62304 검증/확인
-- 시스템 통합자: DLL을 RadiConsole 등 프로덕션 GUI에 연동
+- **영상처리 엔지니어**: 알고리즘 개발 및 튜닝
+- **QA 엔지니어**: IEC 62304 검증/확인 및 테스트 관리
+- **시스템 통합자**: DLL을 RadiConsole 등 프로덕션 GUI에 연동
+- **의료 영상 전문가**: 알고리즘 평가 및 검증
 
-## Development Status
+## 주요 시나리오
 
-- IEC 62304 규정 문서: 완비 (XPE, GSVG, Ghost Correction, Panel Defect)
-- 소스 코드: 스캐폴딩 단계
-- Phase 0 (Foundation) → Phase 1 (Pre/Post Basic) → Phase 2 (Clinical) → Phase 3 (AI)
+### 1. X-ray 이미지 처리 파이프라인
+- **입력**: Raw FPD 데이터 (DICOM 형식, UINT16/FLOAT32)
+- **전처리**: Offset/Dark 보정, Gain 보정, 불량 픽셀 보정 등
+- **후처리**: 노이즈 감소, 대비 향상, 윤곽선 강화 등
+- **출력**: 진단 가능한 의료 영상 (DICOM 표준 준수)
+
+### 2. 알고리즘 개발 및 검증
+- 단위 테스트 및 통합 테스트 수행
+- ImageProcTest GUI로 실시간 알고리즘 검증
+- 성능 벤치마킹 및 품질 평가
+
+### 3. 의료 기기 인증 준비
+- IEC 62304 Class B 합격 지원
+- 요구사항 추적 관리 (RTM)
+- 자동화 테스트 및 검증
+
+## 개발 현황
+
+### 현재 단계
+**Phase 1 진행 중**: 전처리 기본 알고리즘 구현 완료, 기본 후처리 개발 진행 중
+- **Phase 0 완료**: 인프라, 공통 라이브러리, 테스트 프레임워크, GUI 프로토타입, CI/CD
+- **Phase 1**: 기본 전처리(PRE-01~09) 및 기본 후처리(POST-01~04, POST-07) 구현
+- **목표**: 의료 기기 인증 (IEC 62304 Class B)
+
+### 최근 개발 성과
+- **SPEC-XPE-P1A**: 전처리 모듈 (Gain/Offset/Defect Correction) 구현 완료
+- **통합 테스트 GUI**: ImageProcTest WPF GUI로 DLL 모듈 통합 테스트 지원
+- **API 명세**: 완전한 C ABI 규격 82개 함수 구현
+
+### 로드맵 (v2.0 Updated)
+
+**Phase 2 (Differentiator)**: AI 기반 고급 알고리즘 도입 (deterministic 중심)
+- PRE-04 NLCSC Lag Correction (14-50x 업계 우위)
+- PRE-06 ML Defect Correction (14.2x NMSE) — Phase 3 AI tier와 통합
+- POST-05 Multiscale Frequency Processing
+- POST-09 Bone Suppression — Phase 3 AI tier로 분류
+- POST-11 Virtual Grid (GSVG, 별도 IEC 62304 패키지)
+
+**Phase 3 (Intelligence)**: AI 모듈 고도화 (SPEC-XPE-P3-AI v1.0)
+- POST-02 Deep Learning Denoising — SSL (Noise2Noise family) baseline
+- POST-02 Diffusion Priors — opt-in premium tier (NEED/DiffDenoise)
+- POST-07 AI Collimation Detection (baseline Hough + AI refinement)
+- POST-09 Bone Suppression (U-Net, +16.8% 민감도)
+- ONNX Runtime 1.20+ through Multi-EP (CPU/CUDA/TensorRT/DirectML)
+- XAI Sidecar (Grad-CAM saliency, SHAP, opt-in)
+- Conformal Prediction Uncertainty Quantification
+- PCCP boundary enforcement (FDA 2024-12)
+- Model Card API + Data Lineage
+
+**Parallel Tracks (신규 v2.0)**:
+- **S-REG**: FDA/EU/ISO 규제 문서 및 governance (S0-A 이후 병행)
+- **S-SEC**: §524B + SBOM + SLSA (S0-B 이후 병행)
+- **S-OPS**: PMS + Drift + OTEL + Reproducible (S1-B1 이후 병행)
+- **S-IOP**: DICOMweb + FHIR R5 + IHE AIR/AIRA (S1-B3 이후)
+
+**Phase 4 Research Track (Could, 2027+)**: MedSAM fine-tuning, Federated Learning, GPU production path, Rust safety modules.

--- a/.moai/project/tech.md
+++ b/.moai/project/tech.md
@@ -1,58 +1,113 @@
-# Technology Stack
+# 기술 스택 (v2.0)
 
-## Languages
+**Version**: 2.0.0 | **Updated**: 2026-04-17
+**Changes from v1.0**: ONNX Runtime 1.20+, SBOM toolchain, SLSA L2/L3 provenance, CMake Presets v6, OpenTelemetry, IEC 81001-5-1 references. See `.moai/project/trend-survey-2026.md` for rationale.
 
-| Language | Usage | Standard |
-|----------|-------|----------|
-| C/C++ | Native DLL modules (image processing algorithms) | C++17 |
-| C# | Integration test GUI (ImageProcTest) | .NET 8, WPF |
-| C | DLL ABI boundary (P/Invoke compatible exports) | C11 |
+## 프로그래밍 언어
 
-## Build System
+| 언어 | 사용 목적 | 표준 |
+|------|----------|----------|
+| C++17 | 네이티브 DLL 모듈 (이미지 처리 알고리즘) | C++17 표준 |
+| C# | 통합 테스트 GUI (ImageProcTest) | .NET 8, WPF |
+| C11 | DLL ABI 경계 (P/Invoke 호출 가능) | C11 표준 |
 
-| Tool | Version | Purpose |
-|------|---------|---------|
-| CMake | >= 3.25 | C/C++ build system |
-| Ninja | latest | Build generator (via CMakePresets) |
-| vcpkg | manifest mode | SOUP dependency management (pinned versions) |
-| MSBuild | VS 2022 | C# project build |
+## 빌드 시스템
 
-## SOUP Dependencies (XPE)
+| 도구 | 버전 | 목적 |
+|------|------|------|
+| CMake | >= 3.25 | C/C++ 빌드 시스템 |
+| Ninja | 최신 | 빌드 생성기 (CMakePresets 통해) |
+| vcpkg | 매니페스트 모드 | SOUP 의존성 관리 (고정 버전) |
+| MSBuild | VS 2022 | C# 프로젝트 빌드 |
 
-| Component | Version | License | Used By | Purpose |
-|-----------|---------|---------|---------|---------|
-| OpenCV | 4.9.x | Apache 2.0 | preprocess, enhance_basic | Bilateral filter, CLAHE, image ops |
-| DCMTK | 3.6.8 | BSD-3 | dicom | DICOM file/network I/O |
-| Eigen | 3.4.x | MPL-2.0 | enhance_advanced | Matrix ops, FFT |
-| ONNX Runtime | 1.17.x | MIT | ai | DL model inference (U-Net, MobileNet-v3) |
-| spdlog | 1.13.x | MIT | common | Async logging |
-| nlohmann/json | 3.11.x | MIT | common | JSON config parsing |
-| fmt | 10.x | MIT | common | String formatting |
-| Google Test | 1.14.x | BSD-3 | tests | Unit testing framework |
+## 아키텍처 설계
 
-## SOUP Dependencies (GSVG, independent)
+### 3-Layer Anti-Spaghetti 설계
+- **Layer 0**: 공통 타입/메모리 (xpe_common.dll)
+- **Layer 1**: 알고리즘 DLLs (상호 의존 금지, Layer 0에만 의존)
+- **Layer 1-G**: GSVG (독립 IEC 62304 패키지)
+- **Layer 2**: C# GUI Orchestrator (P/Invoke로 모든 DLL 호출)
 
-| Component | Version | License | Purpose |
-|-----------|---------|---------|---------|
-| FFTW3 | 3.3.10 | GPL v2+ | DWT decomposition (dynamic linking required) |
-| OpenCV | 4.9.x | Apache 2.0 | Image operations |
-| Eigen | 3.4.x | MPL-2.0 | Matrix operations |
-| DCMTK | 3.6.8 | BSD-3 | DICOM metadata reading |
-| nlohmann/json | 3.11.x | MIT | Configuration |
+### ABI 설계 규칙
+- **호출 규칙**: `__cdecl` (Windows C 기본값)
+- **구조체 정렬**: `#pragma pack(push, 8)` — 8바이트 정렬
+- **유니버스**: 순수 C 타입만 (`stdint.h`, `stddef.h`)
+- **링크**: `extern "C"` 모든 내보내기 기호
+- **내보내기 매크로**: `__declspec(dllexport)` / `__declspec(dllimport)`
+- **반환 규칙**: 모든 오류 가능 함수는 `XpeErrorCode` 반환
+- **스레드 안전성**: 모든 처리 함수 재진입 가능
 
-## Transitive Dependencies
+## SOUP 의존성 (XPE)
 
-| Component | Via | License | Notes |
-|-----------|-----|---------|-------|
-| OpenSSL | DCMTK | Apache 2.0 | TLS for DICOM network (C-STORE/C-FIND) |
+| 구성 요소 | 버전 | 라이선스 | 사용 위치 | 목적 |
+|-----------|------|---------|----------|------|
+| OpenCV | 4.9.x | Apache 2.0 | preprocess, enhance_basic | 이중 필터, CLAHE, 이미지 연산 |
+| DCMTK | 3.6.8 | BSD-3 | dicom | DICOM 파일/네트워크 I/O |
+| Eigen | 3.4.x | MPL-2.0 | enhance_advanced | 행렬 연산, FFT |
+| ONNX Runtime | **1.20.x+** (v2.0) | MIT | ai | DL 모델 추론. v2.0 업그레이드 근거: TensorRT EP 10.9, DirectML EP, CUDA EP 다중 백엔드 런타임 선택. 기존 U-Net, MobileNet-v3 + 신규 SSL/Diffusion 모델 |
+| spdlog | 1.13.x | MIT | common | 비동기 로깅 |
+| nlohmann/json | 3.11.x | MIT | common | JSON 설정 파싱 |
+| fmt | 10.x | MIT | common | 문자열 서식 지정 |
+| Google Test | 1.14.x | BSD-3 | tests | 단위 테스트 프레임워크 |
 
-## Target Platform
+## SOUP 의존성 (GSVG, 독립)
 
-| OS | Architecture | SIMD |
-|----|-------------|------|
-| Windows 11 (primary) | x86-64 | AVX2 |
-| Ubuntu 24.04 (deferred) | x86-64 | AVX2 |
-| ARM64 (deferred) | aarch64 | NEON |
+| 구성 요소 | 버전 | 라이선스 | 목적 |
+|-----------|------|---------|------|
+| FFTW3 | 3.3.10 | GPL v2+ | DWT 분해 (동적 링크 필요) |
+| OpenCV | 4.9.x | Apache 2.0 | 이미지 연산 |
+| Eigen | 3.4.x | MPL-2.0 | 행렬 연산 |
+| DCMTK | 3.6.8 | BSD-3 | DICOM 메타데이터 읽기 |
+| nlohmann/json | 3.11.x | MIT | 설정 관리 |
+
+## 전이 의존성
+
+| 구성 요소 | 경로 | 라이선스 | 참고 사항 |
+|-----------|------|---------|-----------|
+| OpenSSL | DCMTK | Apache 2.0 | DICOM 네트워크 TLS (C-STORE/C-FIND) |
+
+## 타겟 플랫폼
+
+| OS | 아키텍처 | SIMD |
+|----|----------|------|
+| Windows 11 (주요) | x86-64 | AVX2 |
+| Ubuntu 24.04 (지연) | x86-64 | AVX2 |
+| ARM64 (지연) | aarch64 | NEON |
+
+## 개발 환경
+
+### 필수 도구
+- **Visual Studio 2022**: C++ 및 C# 개발 (Intel C++ Compiler 옵션)
+- **vcpkg**: 의존성 관리 (매니페스트 모드)
+- **CMake**: 빌드 시스템 (Ninja 백엔드)
+- **Git**: 버전 관리
+- **MoAI 프레임워크**: 자동화된 개발 워크플로우
+
+### 빌드 구성
+```bash
+# 개발 환경 설정
+cmake --preset x86-windows-developer
+cmake --build --preset x86-windows-developer
+
+# 릴리즈 빌드
+cmake --preset x86-windows-release
+cmake --build --preset x86-windows-release
+
+# 테스트 실행
+ctest --preset x86-windows-developer
+```
+
+### 테스트 프레임워크
+- **Google Test**: C++ 단위/통합 테스트
+- **xUnit**: C# GUI 테스트
+- **CTest**: 테스트 자동화 및 리포팅
+- **MoAI TDD**: 테스트 주도 개발 워크플로우
+
+### 품질 보장
+- **TRUST 5**: Tested (85%+), Readable, Unified, Secured, Trackable
+- **IEC 62304 Class B**: 의료 기기 소프트웨어 품질 표준
+- **MX 태그 시스템**: 코드 수준 주석 및 경고
+- **자동화된 검증**: MoAI 품질 게이트웨이
 
 ## HW/SW Development Strategy
 
@@ -65,36 +120,41 @@
 | SW-first → MCU | PRE-07 | SWU-1.6 TempCompensator | 온도 센서 LUT 보간. 임베디드 MCU 이관 가능 구조로 구현 |
 | SW-only | PRE-04, PRE-05 | SWU-1.4 GhostCorrector | 복잡한 NLCSC 비선형 모델. Host PC 전용 |
 
+## 개발 전략
+
 ### FPGA 이관 설계 규칙 (SW-first → HW SWUs)
 
-- `xpe_preprocess_configure()` JSON 스키마에 `"hw_mode"` 필드 예비 (미래 FPGA bypass용)
-- 알고리즘 로직 순수 함수(stateless) 선호 → FPGA 포팅 용이
-- `#pragma pack(push, 8)` / Pack=8 레이아웃 유지 → FPGA DMA 호환
+- **프로그래밍 모델**: `xpe_preprocess_configure()` JSON 스키마에 `"hw_mode"` 필드 예비 (미래 FPGA bypass용)
+- **알고리즘 설계**: 순수 함수(stateless) 선호 → FPGA 포팅 용이
+- **메모리 레이아웃**: `#pragma pack(push, 8)` / Pack=8 레이아웃 유지 → FPGA DMA 호환
 
-## Must-Have vs Differentiator
-
-출처: `docs/xray_fpd_tech_classification_final.md` (v2.0, Section 2)
-
-Phase별 기술 우선순위:
+### 기술 우선순위 분류
 
 **Phase 1 — Foundation (필수 기술)**:
-- 전처리 전체(PRE-01~09), Display LUT(POST-12), 기본 후처리(POST-01~04), 기본 Collimation/ROI 기반 워크플로우(POST-07 기본 tier), DICOM(SUP-04), Support 전체(SUP-01~05)
+- 전처리 전체(PRE-01~09), Display LUT(POST-12), 기본 후처리(POST-01~04)
+- 기본 Collimation/ROI 기반 워크플로우(POST-07 기본 tier), DICOM(SUP-04)
+- Support 기술 전체(SUP-01~05)
 
-**Phase 2 — Differentiator**:
-- PRE-04 NLCSC Lag Correction (14-50x 업계 우위), PRE-06 ML Defect (14.2x NMSE), POST-05 MFP/FMP (MUSICA-class), POST-07 AI Collimation, POST-11 Virtual Grid (CNR 2-3x)
+**Phase 2 — Differentiator (차별화 기술)**:
+- PRE-04 NLCSC Lag Correction (14-50x 업계 우위)
+- PRE-06 ML Defect (14.2x NMSE)
+- POST-05 MFP/FMP (MUSICA-class)
+- POST-07 AI Collimation, POST-11 Virtual Grid (CNR 2-3x)
 
-**Phase 3 — Intelligence**:
-- POST-09 DL Bone Suppression (폐결절 민감도 16.8% 향상), POST-02 DL Denoising
+**Phase 3 — Intelligence (AI 고도화)**:
+- POST-09 DL Bone Suppression (폐결절 민감도 16.8% 향상)
+- POST-02 DL Denoising, 고급 추론 최적화
 
-## C ABI Design
+## C ABI 인터페이스 설계
 
-- Struct packing: `#pragma pack(push, 8)` / `[StructLayout(Pack = 8)]`
-- Memory ownership: Caller allocates via xpe_common, caller frees
-- Configuration: JSON string (`const char*`) at boundary
-- Error handling: `int32_t` return codes + `char*` error buffer
-- Thread safety: All exported functions reentrant with independent buffers
+### 핵심 설계 원칙
+- **구조체 정렬**: `#pragma pack(push, 8)` / `[StructLayout(Pack = 8)]`
+- **메모리 소유권**: 호출자가 `xpe_common`으로 할당, 호출자가 해제
+- **설정 전달**: JSON 문자열 (`const char*`) 경계에서
+- **오류 처리**: `int32_t` 반환 코드 + `char*` 오류 버퍼
+- **스레드 안전성**: 모든 내보내기 함수 독립 버퍼로 재진입 가능
 
-### XpeImageMetadata Flags (확장)
+### XpeImageMetadata Flags 확장
 
 ```c
 // XpeImageMetadata.flags 비트 정의
@@ -113,23 +173,134 @@ Phase별 기술 우선순위:
 #define XPE_FLAG_GSVG_SKIPPED            0x00001000u  // GSVG SAFE-003 fallback 발생
 ```
 
-## Testing
+## 테스트 프레임워크
 
-| Framework | Language | Scope |
-|-----------|---------|-------|
-| Google Test + CTest | C++ | Unit tests (SWU-level), integration tests |
-| xUnit | C# | ImageProcTest GUI tests |
+| 프레임워크 | 언어 | 범위 |
+|-----------|------|------|
+| Google Test + CTest | C++ | 단위 테스트 (SWU 레벨), 통합 테스트 |
+| xUnit | C# | ImageProcTest GUI 테스트 |
 
-## Quality Framework
+## 품질 프레임워크
 
-- IEC 62304 Class B compliance
-- TRUST 5: Tested (85%+), Readable, Unified, Secured, Trackable
-- TDD methodology (RED-GREEN-REFACTOR)
-- SWU-to-DLL-to-test traceability (IEC 62304 5.4.1)
+- **IEC 62304 Class B**: 의료 기기 소프트웨어 품질 표준 준수
+- **TRUST 5**: Tested (85%+), Readable, Unified, Secured, Trackable
+- **TDD 방법론**: RED-GREEN-REFACTOR 개발 사이클
+- **추적성**: SWU-to-DLL-to-test 추적 관리 (IEC 62304 5.4.1)
+- **MoAI 워크플로우**: 자동화된 SPEC 관리 및 구현
 
-## License Risks
+## 라이선스 리스크
 
-| Risk | Component | Mitigation |
+| 리스크 | 구성 요소 | 완화 방안 |
 |------|-----------|------------|
-| GPL contamination | FFTW3 (GSVG only) | Dynamic linking only, GSVG as separate DLL |
-| OpenSSL export restrictions | DCMTK transitive | Review per-jurisdiction requirements |
+| GPL 오염 | FFTW3 (GSVG 전용) | 동적 링크만, GSVG 별도 DLL로 분리 |
+| OpenSSL 수출 제한 | DCMTK 전이적 의존 | 관할권별 요구사항 검토 |
+
+## 성능 최적화
+
+### SIMD 지원
+- **AVX2**: Windows 및 Ubuntu x86-64 기본 지원
+- **NEON**: ARM64 대상 지연 계획
+- **벡터화**: 이미지 처리 알고리즘 자동 벡터화
+
+## 공급망 보안 및 빌드 검증 (v2.0 신규)
+
+### SBOM (Software Bill of Materials)
+
+FDA §524B 법적 의무 대응. SPDX 3.0 + CycloneDX 1.6 이중 포맷 지원.
+
+| 도구 | 목적 | 배포 위치 |
+|------|------|----------|
+| **syft** (Anchore) | SBOM 생성 (SPDX/CycloneDX) | CI 자동 실행 |
+| **cyclonedx-cpp-maker** | C/C++ 전용 CycloneDX | 백업 생성기 |
+| **Grype** | SBOM 취약점 스캔 | CI 자동 실행 |
+| **OSV-Scanner** (Google) | 취약점 데이터베이스 스캔 | CI 자동 실행 |
+| **CycloneDX VEX / OpenVEX / CSAF 2.0** | 취약점 대응 문서 | 취약점 보고 시 자동 생성 |
+
+근거: [FDA 2025-06 Cybersecurity Final Guidance](https://www.federalregister.gov/documents/2025/06/27/2025-11669/cybersecurity-in-medical-devices-quality-system-considerations-and-content-of-premarket-submissions), [SPDX 3.0](https://spdx.dev/), [CycloneDX 1.6](https://cyclonedx.org/)
+
+### 공급망 무결성 (SLSA)
+
+SLSA (Supply-chain Levels for Software Artifacts) 기반 빌드 증명:
+
+| 레벨 | 목표 | 구현 |
+|------|------|------|
+| L1 | Provenance 존재 | 기본 CI 로그 |
+| L2 | 서명된 provenance | GitHub Actions SLSA generator (v1.x) |
+| **L3** | 격리된 빌드 환경 | 본 프로젝트 Phase 2 목표. Reusable workflow 사용 |
+
+attestation: in-toto v1.0 spec
+
+근거: [SLSA Specification](https://slsa.dev/spec/v1.0/levels)
+
+### 재현 가능한 빌드 (Reproducible Builds)
+
+- **SOURCE_DATE_EPOCH** 환경변수 준수
+- **CMake/Ninja**: `__DATE__`/`__TIME__` 매크로 프로덕션 빌드 배제
+- **Windows**: MSVC `/Brepro` 링커 플래그
+- **검증**: `scripts/verify_reproducible.sh` (2회 빌드 byte-identical 비교)
+
+근거: [reproducible-builds.org](https://reproducible-builds.org/)
+
+## 관측성 (Observability, v2.0 신규)
+
+### OpenTelemetry 통합 (Should, opt-in)
+
+| 요소 | 버전 | 용도 |
+|------|------|------|
+| OpenTelemetry C++ SDK | 1.x+ | xpe_common OTEL Tracer/Meter/Logger API |
+| OTLP 내보내기 | HTTP/protobuf 및 gRPC | 수집 endpoint |
+| Semantic Conventions | 표준 | `xpe.stage.name`, `xpe.swu.id` |
+| **Profiling Signal** | 2024 도입 | 지속적 프로파일링 지원 |
+
+엔진 기본값: OFF. 활성화 시 site configuration으로 설정.
+
+근거: [OpenTelemetry 2025 roadmap](https://opentelemetry.io/blog/2025/)
+
+### Drift Detection (AI 모듈)
+
+AI 모듈은 추론 시 input fingerprint 생성, 하기 검출기 지원:
+
+- Kolmogorov-Smirnov 테스트 (per-feature)
+- Maximum Mean Discrepancy (MMD, deep kernel)
+- Classifier-based drift detector
+
+근거: [Nature Digital Medicine "Distribution shift detection"](https://www.nature.com/articles/s41746-024-01085-w), [Nature Communications "Empirical data drift"](https://www.nature.com/articles/s41467-024-46142-w)
+
+## 규제 표준 매핑 (v2.0 신규)
+
+XPE 프로젝트가 준수하는 표준 및 가이던스:
+
+| 표준/가이던스 | 분류 | 역할 | 대응 SPEC |
+|--------------|:----:|------|----------|
+| IEC 62304:2006+A1:2015 | Normative | SW 라이프사이클 (Class B) | 기존 |
+| **IEC 81001-5-1:2021** | Normative | 보안 SW 라이프사이클 (64 요구사항) | SPEC-XPE-SEC |
+| ISO 13485:2016 | Normative | QMS | QMSR 2026 통합 |
+| ISO 14971:2019 | Normative | 리스크 관리 | 기존 |
+| **ISO/IEC 42001:2023** | Normative | AI Management System | SPEC-XPE-REG |
+| **FDA §524B** | Law | Cyber Device 사이버보안 | SPEC-XPE-SEC |
+| **FDA PCCP Final 2024-12** | Guidance | AI-DSF 사전승인 변경 | SPEC-XPE-REG |
+| **FDA AI-DSF Lifecycle Draft 2025-01** | Guidance | TPLC AI 접근 | SPEC-XPE-REG |
+| **FDA Transparency 2024-06** | Guidance | ML-MD 투명성 | SPEC-XPE-REG |
+| **IMDRF GMLP N88 Final 2025-01** | Guidance | 10대 원칙 | SPEC-XPE-REG |
+| **EU Regulation 2024/1689 (AI Act)** | Law | High-Risk AI | SPEC-XPE-REG |
+| EU Regulation 2017/745 (MDR) | Law | 의료기기 | 기존 |
+| DICOM PS 3.1-3.20 | Normative | 상호운용성 | SPEC-XPE-IOP |
+| HL7 FHIR R5 | Normative | 의료 정보 교환 | SPEC-XPE-IOP |
+| IHE RAD TF Rev 23.0 (2025-08) | Normative | 프로필 | SPEC-XPE-IOP |
+
+## 빌드 시스템 업그레이드 (v2.0 신규)
+
+- **CMake Presets v6**: workflow presets + configure/build/test 조합
+- **vcpkg**: 매니페스트 모드 (기존) + 커스텀 registry (Phase 2)
+- **GitHub Actions**: Reusable workflows for SBOM/SLSA
+- **cibuildwheel/toolchain**: 결정적 빌드 환경
+
+### 메모리 관리
+- **메모리 풀**: xpe_common.dll에서 제공
+- **버퍼 재사용**: 스레드 로컬 버퍤 풀링
+- **페이지 관리**: 대용량 이미지 효율적 처리
+
+### 멀티 스레딩
+- **스레드 풀**: 작업 병렬 처리
+- **무상태 설계**: 스레드 간 상태 공유 없음
+- **스케일링**: 코어 수에 따른 자동 스레드 수 조절

--- a/.moai/project/trend-survey-2026.md
+++ b/.moai/project/trend-survey-2026.md
@@ -1,0 +1,679 @@
+# XPE 2026 Trend Survey & Must/Should/Could Matrix
+
+**Document ID**: TREND-SURVEY-2026-001
+**Version**: 1.1.0 (Strict Reclassification)
+**Date**: 2026-04-17
+**Author**: MoAI (deep-survey + brainstorming)
+**Status**: Normative Input for SPEC-XPE-MASTER v3.0.0 및 신규 SPEC 4종
+**Classification**: IEC 62304 Class B (Input Document)
+
+## Revision History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2026-04-17 | Initial survey, Must 27 / Should 19 / Could 10 |
+| **1.1.0** | 2026-04-17 | **Strict Must reclassification**: Must 27→12, Should 19→34 (no duplicate). 진행 블로커 아닌 항목 전부 Should로 강등. 사용자 요구 "반드시 필수일때만 must로 분류" 반영. |
+
+---
+
+## 0. 서베이 방법론
+
+### 0.1 범위와 전제
+
+본 서베이는 2024-2026년 의료영상 소프트웨어 도메인의 다음 5개 축을 교차검증으로 분석한다:
+
+1. **Regulatory (규제)** — FDA, EU, IMDRF, ISO, IEC
+2. **Cybersecurity (보안)** — SBOM, SLSA, threat modeling, lifecycle security
+3. **Interoperability (상호운용성)** — DICOMweb, FHIR R5, IHE RAD
+4. **AI/ML Advancement (지능 고도화)** — SSL, diffusion, foundation models, UQ
+5. **Operations/Observability (운영)** — drift detection, post-market, telemetry
+
+각 트렌드는 **Must / Should / Could** 3-티어로 분류하며, **사용자 요구사항에 따라 "기본으로 필수인 항목은 반드시 Must"** 로 배치한다.
+
+### 0.2 분류 기준 (v1.1 엄격 버전)
+
+| 티어 | 의미 | 판정 기준 |
+|------|------|-----------|
+| **Must** | **진짜 블로커**. 없으면 출시 불가 또는 법적 처벌 | (1) 법률 의무 (Guidance 아닌 Law, 현 배포 범위에 적용), (2) 시장 진입 거절 사유, (3) IEC 62304 Class B 강제 조항, (4) 기본 방어적 안전 (입력 검증 등) |
+| **Should** | **강력 권장**. 경쟁력·현대 설계·자발적 표준 | 자발적 인증(ISO 42001, IEC 81001-5-1), 최종 아닌 Draft guidance, 프로젝트 아키텍처 원칙, 범위 조건부 규제(FDA PCCP는 AI 배포 시에만 Must), 통합 편의성, 업계 베스트 프랙티스 |
+| **Could** | 미래 옵션·실험 | 2027+ 대비, Phase 4 연구 모드 |
+
+**엄격 판정 질문**: "이것이 없으면 프로젝트가 출시하지 못하거나 법적으로 거절됩니까?"
+- 예 → Must
+- 아니오 → Should (강력 권장이더라도)
+
+**범위 의존 판정 예시**:
+- FDA PCCP: AI-DSF 배포 시에만 Must. 결정적 전용 릴리스는 Should
+- EU AI Act High-Risk: EU에 AI 판매 시에만 Must. US 결정적 전용은 Should
+- IEC 81001-5-1: 자발적 표준 → 항상 Should
+- ISO/IEC 42001: 자발적 인증 → 항상 Should
+
+### 0.3 근거 수집 통계
+
+| 축 | WebSearch 횟수 | 주요 공식 소스 |
+|----|:-------------:|----------------|
+| Regulatory | 9 | FDA.gov, Federal Register, IMDRF, ISO, EU Commission |
+| Cybersecurity | 6 | FDA 524B, SPDX.org, CycloneDX.org, SLSA.dev, MITRE |
+| Interoperability | 4 | DICOM.org, HL7.org, IHE.net |
+| AI/ML | 6 | FDA, MICCAI, Nature, arXiv, GitHub bowang-lab |
+| Operations | 3 | FDA, MHRA, OpenTelemetry.io |
+
+**Total**: 28 web queries, 2024-2026 최신성 교차검증 완료.
+
+---
+
+## 1. Must Tier: 진짜 블로커만 (12 항목, v1.1 엄격)
+
+**v1.0 27개 → v1.1 12개**. 15개는 Should로 강등 (§2.0 참조).
+
+### 1.0 Must 최종 목록 (요약)
+
+| ID | 항목 | 블로커 판정 근거 |
+|:--:|------|-----------------|
+| M-01 | IEC 62304 Class B | 의료기기 SW 법적 분류 (필수 증명) |
+| M-02 | EU MDR 2017/745 | EU 시장 진입 법률 (Regulation, directly applicable) |
+| M-03 | FDA 21 CFR 820.30 + QMSR 2026 | US 시장 진입 법률 |
+| M-04 | FDA §524B Cyber Device | 2023 법률 (DICOM 네트워크 장비 = 강제 cyber device) |
+| M-05 | SBOM (§524B 하위 필수) | §524B 법적 구성요소 |
+| M-06 | Vulnerability Management | §524B 판매 후 법적 의무 + EU MDR Art 83 |
+| M-07 | Basic Input Validation | IEC 62304 + 기본 방어 (defect prevention) |
+| M-08 | DICOM 3.0 Core | 병원 PACS 통합 필수 (실질적 시장 블로커) |
+| M-09 | DICOM Conformance Statement | 병원 구매 실사 법적 증빙 요구 |
+| M-10 | Post-Market Surveillance | EU MDR Article 83 법률 + MHRA Regs |
+| M-11 | Characterization Tests | IEC 62304 §5.4.1 강제 unit test 조항 |
+| M-12 | Trackability (commits, RTM) | IEC 62304 §5.4.1 추적성 강제 |
+
+### 1.1 Regulatory Baseline (Must · 의무)
+
+**⚠️ [v1.1 강등 → §2.0 Should로 이동]** 이전 v1.0에서 Must로 분류했던 다음 항목들은 v1.1에서 Should로 강등되었다. 근거는 §2.0 참조.
+
+**구 M-REG-01: FDA PCCP (Predetermined Change Control Plan)** — **Should 강등**
+- **무엇**: AI-enabled 의료기기가 재승인 없이 모델 업데이트 가능하도록 사전 승인받는 프레임워크
+- **근거**: FDA Final Guidance "Marketing Submission Recommendations for a Predetermined Change Control Plan for Artificial Intelligence-Enabled Device Software Functions" (2024-12-03)
+- **XPE 적용**: Phase 3 AI 모듈(PRE-06 ML, POST-09 Bone Suppression)의 재훈련 경로 사전 정의
+- **강등 이유**: AI-DSF 미배포 시(Phase 1/2 결정적 전용 릴리스) 블로커가 아님. AI 탑재 Phase 3 진입 시 Must로 승격 조건부
+
+**구 M-REG-02: FDA Lifecycle Management Draft (AI-DSF TPLC)** — **Should 강등**
+- **무엇**: AI 소프트웨어 기능의 Total Product Life Cycle 접근
+- **근거**: FDA Draft Guidance (2025-01-07), 2025-04-07 의견 종료, Final 대기
+- **강등 이유**: (1) Draft 상태 (Final 아님), (2) AI-DSF 배포 시에만 해당, (3) 결정적 전용 Phase 1/2 릴리스는 비해당
+
+**구 M-REG-03: FDA Transparency for ML-enabled Medical Devices** — **Should 강등**
+- **무엇**: 모델 성능·데이터 특성·알고리즘 설명 투명성 원칙
+- **근거**: FDA Guiding Principles (2024-06) — Law가 아닌 Guidance
+- **강등 이유**: ML/AI 기능에만 적용. 결정적 릴리스 블로커 아님
+
+**구 M-REG-04: IMDRF GMLP N88 (10 Guiding Principles, 2025)** — **Should 강등**
+- **무엇**: FDA+Health Canada+MHRA 공동 Good Machine Learning Practice 10대 원칙
+- **근거**: IMDRF/AIML WG/N88 FINAL:2025 (2025-01-27) — Guiding Principle (Law 아님)
+- **강등 이유**: AI 관련만 해당, 결정적 릴리스 비해당
+
+**구 M-REG-05: EU AI Act High-Risk Compliance** — **Should 강등 (조건부)**
+- **무엇**: MDR Class IIa/IIb/III 의료기기 내 AI 시스템 High-Risk AI 분류
+- **근거**: Regulation (EU) 2024/1689, 2024-08 발효, 의료기기 AI 2027-08 전면 적용
+- **강등 이유**: EU에 AI 탑재 의료기기 판매 시에만 Must. US-only 또는 결정적 전용 릴리스 비해당
+- **승격 조건**: EU 시장 + Phase 3 AI 배포 계획 확정 시 Must로 승격
+
+**M-02 (ID 이전 M-REG-06): EU MDR 2017/745 Compliance** — **Must 유지**
+- **무엇**: Medical Device Regulation 준수 (Class B 의료기기 소프트웨어)
+- **근거**: Regulation (EU) 2017/745, MDCG 2019-11 업데이트, MDCG 2025-4, MDCG 2025-9
+- **XPE 적용**: 기존 IEC 62304 Class B 준수 유지 + MDCG 가이던스 매트릭스
+- **Why Must**: EU 시장 진입 법률 (Regulation, 직접 적용)
+
+**구 M-REG-07: ISO/IEC 42001:2023 AI Management System** — **Should 강등**
+- **무엇**: 세계 최초 AI 관리 시스템 표준
+- **근거**: ISO/IEC 42001:2023 (2023-12) — 자발적 인증
+- **강등 이유**: 법적 의무 아님 (자발적). 강력 권장이나 없어도 출시 가능. 병원 구매 조건으로 확산 중이나 블로커 아님
+
+**M-01 (ID 이전 M-REG-08): IEC 62304 Class B** — **Must 유지**
+- **무엇**: 의료기기 소프트웨어 수명주기 프로세스
+- **근거**: IEC 62304:2006/Amd.1:2015, 프로젝트 기본 준거
+- **XPE 적용**: 기존 SRS, SDD, SWU, RTM 체계 유지
+- **Why Must**: 의료기기 SW 분류 법적 증명 근거. Class B SW 없이는 IEC 62304 준수 불가능
+
+**M-03 (ID 이전 M-REG-09): FDA 21 CFR 820.30 Design Controls + 2026 QMSR** — **Must 유지**
+- **무엇**: 디자인 컨트롤, 리스크 관리, 검증/확인
+- **근거**: 2026-02-02 QMSR 발효 (구 QSR 대체, ISO 13485 통합)
+- **XPE 적용**: 디자인 히스토리 파일(DHF), 리스크 관리 파일(ISO 14971) 유지
+- **Why Must**: FDA 승인 법적 의무
+
+### 1.2 Cybersecurity Baseline (Must · 법적 의무만)
+
+**M-04 (이전 M-SEC-01): FDA Section 524B Cybersecurity (Cyber Device)** — **Must 유지**
+- **무엇**: 소프트웨어 포함 + 인터넷 연결 의료기기 프리마켓 사이버보안 의무
+- **근거**: Consolidated Appropriations Act 2023 §3305 (FD&C Act §524B 신설), FDA Final Guidance (2025-06-27)
+- **XPE 적용**: SPDF, 취약점 대응
+- **Why Must**: 법률 (Law), XPE DICOM 네트워크 장비 = 강제 cyber device
+
+**M-05 (이전 M-SEC-02): SBOM** — **Must 유지**
+- **무엇**: SPDX 3.0 / CycloneDX 1.6 기계 판독 가능 SBOM
+- **근거**: FDA §524B 하위 법적 필수 구성요소
+- **Why Must**: §524B 준수의 직접 증빙
+
+**구 M-SEC-03: IEC 81001-5-1 Secure Software Lifecycle** — **Should 강등**
+- **무엇**: 64개 의료기기 SW 사이버보안 요구사항
+- **근거**: IEC 81001-5-1:2021 — 자발적 표준
+- **강등 이유**: FDA가 "acceptable framework"로 인용하나 법적 강제 아님. 엄격 기준 적용 시 Should
+
+**M-06 (이전 M-SEC-04): Cybersecurity Risk Management (Postmarket Vulnerability Monitoring)** — **Must 유지**
+- **무엇**: 판매 후 취약점 감시·보고·패치 프로세스
+- **근거**: FDA §524B (postmarket), EU MDR Article 83 (PMS 일부)
+- **Why Must**: 판매 후 법적 의무
+
+**M-07 (이전 M-SEC-05): Basic Input Validation** — **Must 유지**
+- **무엇**: 모든 외부 입력(DICOM, config, P/Invoke) 경계 검증
+- **근거**: IEC 62304 §5.1.1 방어적 프로그래밍, 기본 안전 원칙
+- **XPE 적용**: C ABI 경계에서 `XpeErrorCode` 반환 + 버퍼 크기 검증 + JSON 스키마 검증
+- **Why Must**: defect prevention 기본 방어 (IEC 62304 강제 조항과 결합)
+
+### 1.3 Interoperability Baseline (Must · 시장 진입)
+
+**M-08 (이전 M-IOP-01): DICOM 3.0 Core Conformance** — **Must 유지**
+- **무엇**: DICOM 3.0 표준 준수
+- **근거**: NEMA DICOM standard, 병원 PACS 통합의 de facto 조건
+- **Why Must**: DICOM 없이는 어떤 병원도 구매 불가 → 실질적 시장 블로커
+
+**M-09 (이전 M-IOP-02): DICOM Conformance Statement** — **Must 유지**
+- **무엇**: 장비·SW가 지원하는 DICOM 기능의 공식 선언 문서
+- **근거**: DICOM PS 3.2 명세, 병원 구매 실사 증빙
+- **Why Must**: 병원 구매 실사 법적 요구 문서 (구매 블로커)
+
+**구 M-IOP-03: IHE RAD Profiles (SWF.b/PDI/PIR)** — **Should 강등**
+- **무엇**: Scheduled Workflow (SWF.b), Portable Data (PDI), Patient Information Reconciliation (PIR)
+- **근거**: IHE RAD Technical Framework Rev 23.0
+- **강등 이유**: DICOM 핵심만 있으면 통합 가능. IHE는 통합 편의성 향상 수단이지 블로커 아님. Connectathon 참여는 권장이지 강제 아님
+
+### 1.4 Quality Baseline (Must · IEC 62304 강제 조항만)
+
+**M-11 (이전 M-QUAL-03): Characterization Test + Unit Test** — **Must 유지**
+- **근거**: IEC 62304 §5.4.1 Unit test 강제 조항, Class B SW 증명 필수
+- **XPE 적용**: Phase 1a/1b 전체 SWU에 unit/characterization test
+- **Why Must**: IEC 62304 강제 조항 (법적 의무)
+
+**M-12 (이전 Trackability): Trackability (commits, RTM, issue)** — **Must 유지**
+- **근거**: IEC 62304 §5.4.1 추적성 강제 조항
+- **XPE 적용**: Conventional commits, @MX:DOC 링크, PR 트레이싱, RTM
+- **Why Must**: IEC 62304 강제 조항
+
+**⚠️ [v1.1 강등]**:
+
+**구 M-QUAL-01: TRUST 5 Framework** — **Should 강등**
+- **강등 이유**: 프로젝트 자체 채택 프레임워크. 개별 구성요소(Tested, Trackable)는 별도 Must에 분산. 전체 브랜드로는 Should 수준
+
+**구 M-QUAL-02: Deterministic Reference + SIMD Parity** — **Should 강등**
+- **강등 이유**: 아키텍처 품질 원칙. 권장되나 없어도 출시 가능 (다만 품질 저하)
+
+**구 M-QUAL-04: MX Tag System** — **Should 강등**
+- **강등 이유**: 프로젝트 내부 관례. 외부 규제·고객 요구 없음
+
+**구 M-QUAL-05: Anti-Spaghetti Architecture** — **Should 강등**
+- **강등 이유**: 내부 설계 원칙. 지키지 않아도 출시 가능 (다만 유지보수 부담)
+
+### 1.5 Operations Baseline (Must · 법적 의무만)
+
+**M-10 (이전 M-OPS-01): Post-Market Surveillance (PMS)** — **Must 유지**
+- **무엇**: 판매 후 안전·성능 추적 및 심각 사고 보고
+- **근거**: EU MDR 2017/745 Article 83, MHRA PMS Regs (2025-06-16 발효)
+- **XPE 적용**: Reject-analysis, DI drift telemetry 최소 구현
+- **Why Must**: EU MDR Article 83 법률
+
+**⚠️ [v1.1 강등]**:
+
+**구 M-OPS-02: Reproducible Builds (SLSA L1+)** — **Should 강등**
+- **강등 이유**: SBOM/SLSA 전제이나 법적 의무 아님. Reproducibility 없어도 SBOM은 발급 가능
+
+**구 M-OPS-03: Version Control + Traceability**
+- **통합**: Trackability로 M-12에 흡수 (IEC 62304 §5.4.1 강제 조항)
+
+### 1.6 AI Baseline (v1.1 전체 Should 강등)
+
+**⚠️ [v1.1 강등]** AI 모듈은 Phase 3 배포 시에만 적용. 결정적 전용 Phase 1/2 릴리스는 AI 비해당 → Must 제외.
+
+**구 M-AI-01: Model Card Documentation** — **Should 강등**
+- **강등 이유**: AI-DSF 배포 시에만 필요. FDA Transparency는 Guidance (Law 아님)
+
+**구 M-AI-02: Data Lineage** — **Should 강등**
+- **강등 이유**: AI 배포 시에만. GMLP는 Guiding Principle
+
+**구 M-AI-03: Deterministic Fallback** — **Should 강등**
+- **강등 이유**: AI 배포 시 안전 원칙. AI 미배포 시 비해당
+
+**승격 조건**: Phase 3 AI 배포 확정 시 위 3항목은 Must로 승격.
+
+---
+
+## 2. Should Tier: 강력 권장 (34 항목, v1.1 확장)
+
+### 2.0 v1.1 신규 추가 (v1.0 Must → Should 강등 15항목)
+
+| 신규 ID | 항목 | 강등 출처 | 재배치 근거 |
+|:-------:|------|:---------:|-------------|
+| S-REG-03 | FDA PCCP | v1.0 M-REG-01 | AI-DSF 배포 조건부 |
+| S-REG-04 | FDA AI-DSF Lifecycle (Draft) | v1.0 M-REG-02 | Draft 상태 + AI 조건부 |
+| S-REG-05 | FDA Transparency for ML-MD | v1.0 M-REG-03 | Guidance + AI 조건부 |
+| S-REG-06 | IMDRF GMLP N88 | v1.0 M-REG-04 | Guiding Principle |
+| S-REG-07 | EU AI Act High-Risk | v1.0 M-REG-05 | EU+AI 조건부 |
+| S-REG-08 | ISO/IEC 42001 | v1.0 M-REG-07 | 자발적 인증 |
+| S-SEC-05 | IEC 81001-5-1 | v1.0 M-SEC-03 | 자발적 표준 |
+| S-IOP-05 | IHE RAD Profiles (SWF.b/PDI/PIR) | v1.0 M-IOP-03 | 통합 편의성 |
+| S-QUAL-01 | TRUST 5 Framework | v1.0 M-QUAL-01 | 프로젝트 프레임워크 |
+| S-QUAL-02 | Reference + SIMD Parity | v1.0 M-QUAL-02 | 아키텍처 원칙 |
+| S-QUAL-03 | MX Tag System | v1.0 M-QUAL-04 | 내부 관례 |
+| S-QUAL-04 | Anti-Spaghetti 3-Layer | v1.0 M-QUAL-05 | 내부 설계 |
+| S-OPS-05 | Reproducible Builds | v1.0 M-OPS-02 | SLSA 전제 |
+| S-AI-06 | Model Card (구 M-AI-01) | v1.0 M-AI-01 | AI 조건부 |
+| S-AI-07 | Data Lineage (구 M-AI-02) | v1.0 M-AI-02 | AI 조건부 |
+| S-AI-08 | Deterministic Fallback (구 M-AI-03) | v1.0 M-AI-03 | AI 안전 조건부 |
+
+### 2.1 Regulatory Should
+
+**S-REG-01: NIST AI RMF Profile**
+- **근거**: NIST AI 100-1 (2023-01), Gen AI Profile AI 600-1 (2024-07-26)
+- **주의**: AAMI 지적 — 의료기기 리스크 모델과 직접 맞지 않음. **Profile 스타일로 부분 채택**
+- **적용**: 투명성·설명성 부분만 참조 (FDA Guidance와 중첩)
+
+**S-REG-02: Bias Analysis + Fairness Metrics**
+- **근거**: FDA Transparency 2024, EU AI Act §10 (데이터 거버넌스)
+- **적용**: 인구통계(성별·연령·인종) 층위 성능 리포트
+
+### 2.2 Cybersecurity Should
+
+**S-SEC-01: SLSA Level 3 Build Provenance**
+- **무엇**: 격리된 빌드 환경에서 생성된 서명된 provenance
+- **근거**: SLSA v1.0/1.1, in-toto attestation
+- **적용**: GitHub Actions reusable workflow로 L2→L3 점진
+- **Why Should**: FDA가 법적 요구하진 않으나, 공급망 사고 시 강력한 방어선
+
+**S-SEC-02: STRIDE + MITRE EMB3D Threat Modeling**
+- **근거**: MITRE EMB3D (2024 enhanced, IEC 62443-4-2 alignment), MDIC Playbook
+- **적용**: xpe_dicom 네트워크 경계 + C# GUI P/Invoke 경계 위협 모델
+
+**S-SEC-03: SBOM Continuous Delivery (CVE Feed 연동)**
+- **근거**: NVD CVE API, GitHub Advisory DB
+- **적용**: CI에서 SBOM → OSV-Scanner + Grype 자동 스캔
+
+**S-SEC-04: Coordinated Vulnerability Disclosure (CVD)**
+- **근거**: FDA 524B, ISO/IEC 29147
+- **적용**: SECURITY.md, PGP 키, 개별 disclosure 프로세스
+
+### 2.3 Interoperability Should
+
+**S-IOP-01: DICOMweb (WADO-RS / STOW-RS / QIDO-RS)**
+- **무엇**: DICOM의 RESTful 웹 전송 계층
+- **근거**: DICOM PS 3.18, AWS HealthImaging (2025-05 QIDO-RS 확장), Orthanc, dcm4che
+- **적용**: xpe_dicom에 DICOMweb 클라이언트/서버 선택 지원
+- **Why Should**: 2026년 PACS 현대화 추세, 병원 통합 가속
+
+**S-IOP-02: FHIR R5 ImagingStudy + ImagingSelection**
+- **근거**: FHIR R5 (Maturity 4 for ImagingStudy), HL7 Imaging Integration WG
+- **적용**: DICOM SR → FHIR Observation 매핑 어댑터
+
+**S-IOP-03: IHE AIR / AIRA Profile (AI Results)**
+- **근거**: IHE RAD_Suppl_AIR, IHE RAD_Suppl_AIRA (2025-06-12 발행)
+- **적용**: AI 출력(Bone Suppression, Collimation)을 AIR 프로필로 전달
+
+**S-IOP-04: DICOM Structured Reports for AI Output**
+- **근거**: DICOM Supplement (JSON representation of SR)
+- **적용**: AI 결과를 SR로 래핑 → PACS 통합 용이성
+
+### 2.4 AI/ML Should (차별화 기술)
+
+**S-AI-01: Self-Supervised Denoising (Noise2Noise family)**
+- **근거**:
+  - MICCAI 2025: N2D (Noise2Detail), VQ-SCD, Speckle2Self
+  - Noise2Sim (PMC 2023+)
+  - Neighboring Slice N2N (arXiv 2024)
+- **적용**: Phase 3 POST-02 DL Denoising에 SSL 도입 (ground truth 불필요)
+- **Why Should**: 라벨링 비용 대폭 절감, 규제 데이터 확보 부담 완화
+
+**S-AI-02: Diffusion Priors for Low-Dose Enhancement**
+- **근거**:
+  - Diffusion Probabilistic Priors Zero-Shot (Medical Physics 2025)
+  - NEED (Noise-Inspired Diffusion, 2025)
+  - DiffDenoise (arXiv 2504.00264)
+  - SAD (Structure-Aware Diffusion, 2024)
+- **적용**: premium opt-in tier로 diffusion 기반 denoising 제공
+- **Why Should**: MICCAI 2024-2025 SOTA, perceptual quality 우위
+
+**S-AI-03: Explainable AI Sidecar (Grad-CAM + SHAP)**
+- **근거**:
+  - BMC Medical Imaging Systematic Review (2025)
+  - FDA Transparency Guidance (2024-06)
+- **주의**: Post-hoc 설명성의 한계 인지, clinical misleading 리스크
+- **적용**: AI 출력에 saliency map sidecar 병행 (선택적 표시)
+
+**S-AI-04: Conformal Prediction Uncertainty Quantification**
+- **근거**: COPA 2025, Nature Digital Medicine, arXiv 2503.23819
+- **적용**: Bone Suppression 등에 prediction set + coverage guarantee
+- **Why Should**: FDA postmarket monitoring 친화적 통계 보증
+
+**S-AI-05: ONNX Runtime 1.20+ with Multi-EP**
+- **근거**: ONNX Runtime TensorRT EP 10.9, DirectML EP, CUDA EP
+- **적용**: 배포 환경에 따라 CPU/CUDA/TensorRT/DirectML 선택
+- **Why Should**: 기존 ONNX Runtime 1.17 대비 성능·호환성 개선
+
+### 2.5 Operations Should
+
+**S-OPS-01: Data/Concept Drift Detection**
+- **근거**:
+  - Nature Digital Medicine "Distribution shift detection for postmarket surveillance" (2024)
+  - Nature Communications "Empirical data drift detection" (2024)
+- **적용**: AI 모듈에 classifier-based + deep kernel + multi-univariate KS 탐지기
+
+**S-OPS-02: OpenTelemetry Instrumentation**
+- **근거**: OpenTelemetry 2025 (Profiling signal, edge observability)
+- **적용**: xpe_common에 OTEL Tracer/Meter API 통합 (opt-in, off by default)
+
+**S-OPS-03: Reject-Analysis Telemetry**
+- **근거**: AAPM TG-151 Ongoing QC, score-plan §6
+- **적용**: 재촬영 이벤트 로깅 + 패턴 분석 대시보드
+
+**S-OPS-04: SBOM → VEX Automation**
+- **근거**: CycloneDX VEX, OpenVEX, CSAF 2.0
+- **적용**: SBOM 취약점 발견 시 VEX 문서 자동 생성 (exploitable/not)
+
+---
+
+## 3. Could Tier: 미래 옵션·실험적 (10 항목)
+
+**C-AI-01: MedSAM / MedSAM2 Foundation Model**
+- **근거**: bowang-lab MedSAM (Nature Comms 2024), MedSAM2 (2025-04), LiteMedSAM (10x 가속)
+- **적용**: Phase 4 연구 모드 — collimation ROI 또는 anatomy segmentation 사전학습
+- **Why Could**: 규제 경계 위험 (foundation model governance 미확립)
+
+**C-AI-02: Federated Learning Infrastructure**
+- **적용**: 다중 병원 데이터 주권 유지 학습
+- **Why Could**: 연구 프로젝트 단위, post-market 전략
+
+**C-AI-03: Generative AI (RadImageGAN)**
+- **적용**: 합성 phantom, 훈련 데이터 증강
+- **Why Could**: 데이터 합성 vs 규제 신뢰성 트레이드오프
+
+**C-OPS-01: GPU Offload Production Path (CUDA/DirectML)**
+- **적용**: 고해상도 CBCT 또는 실시간 형광투시
+- **Why Could**: Phase 3 말 선택, 규제 재승인 리스크 고려
+
+**C-ARCH-01: Rust Safety-Critical Module**
+- **적용**: xpe_safety_core 실험 (메모리 안전)
+- **Why Could**: FDA 신기술 호평, SOUP 재평가 필요
+
+**C-ARCH-02: WebAssembly Port (Browser Review)**
+- **적용**: 교육·2차 의견 수집 뷰어
+- **Why Could**: 새로운 배포 형태
+
+**C-SEC-01: Quantum-Resistant Cryptography (NIST PQC)**
+- **적용**: 장기 DICOM 서명 보존
+- **Why Could**: 2027+ 대비
+
+**C-REG-01: NIST AI RMF Gen AI Profile 전체 채택**
+- **적용**: 생성형 AI 기능 도입 시
+- **Why Could**: 아직 의료기기 핏 부족
+
+**C-OPS-02: Continuous Learning (Online Adaptation)**
+- **Why Could**: PCCP 범위 초과 가능성 → regulatory 리스크 높음
+
+**C-IOP-01: FHIRcast Real-Time Sync**
+- **근거**: HL7 FHIRcast (radiology workflow)
+- **적용**: 판독 워크스테이션 실시간 동기화
+- **Why Could**: 현재 스코프 초과
+
+---
+
+## 4. 분류 요약 매트릭스 (v1.1 엄격 재분류)
+
+### 4.1 최종 매트릭스
+
+| 축 | Must (v1.1) | Should (v1.1) | Could | 합계 |
+|----|:----:|:------:|:-----:|:----:|
+| Regulatory | 3 (M-01, M-02, M-03) | 8 (기존 2 + 강등 6) | 1 | 12 |
+| Cybersecurity | 4 (M-04, M-05, M-06, M-07) | 5 (기존 4 + 강등 1) | 1 | 10 |
+| Interoperability | 2 (M-08, M-09) | 5 (기존 4 + 강등 1) | 1 | 8 |
+| AI/ML | 0 | 8 (기존 5 + 강등 3) | 3 | 11 |
+| Operations | 1 (M-10) | 5 (기존 4 + 강등 1) | 2 | 8 |
+| Quality/Architecture | 2 (M-11, M-12) | 4 (강등) | 2 | 8 |
+| **Total** | **12** | **35** | **10** | **57** |
+
+### 4.2 v1.0 대비 변화
+
+| 구분 | v1.0 | v1.1 | 변화 |
+|------|:----:|:----:|:----:|
+| Must | 27 | **12** | **-15** |
+| Should | 19 | **35** | **+16** |
+| Could | 10 | 10 | 0 |
+
+(총합 증가 55→57: 중복 정리 및 M-QUAL-03/Trackability 분리)
+
+### 4.3 원칙 (v1.1 엄격)
+
+**Must 판정**: "이것이 없으면 출시 불가 또는 법적 거절?" → YES만 Must
+
+**Must 12항목 특성**:
+- 8개 항목은 **Law** (법률): IEC 62304, EU MDR, 21 CFR 820/QMSR, FDA §524B, SBOM(§524B 하위), Vulnerability Mgmt(§524B), PMS(EU MDR), Char. Test (IEC 62304)
+- 2개 항목은 **실질적 시장 블로커**: DICOM 3.0 Core, DICOM Conformance Statement
+- 2개 항목은 **기본 안전·추적성**: Basic Input Validation, Trackability
+
+**Should 35항목**: 강력 권장이나 없어도 출시 가능. Phase 2/3 진입 시 일부는 조건부 Must 승격 (AI-DSF 배포 시, EU 판매 시 등).
+
+---
+
+## 5. SPEC 업그레이드 패키지 매핑 (v1.1 엄격 반영)
+
+### 5.1 신규 SPEC 4종 (Must vs Should 혼합 스펙)
+
+| SPEC | Must (v1.1) | Should (v1.1) | 진행 우선순위 |
+|------|-------------|---------------|:------------:|
+| **SPEC-XPE-REG** | M-01 (IEC 62304), M-02 (EU MDR), M-03 (21 CFR/QMSR) | S-REG-03~08 (PCCP, AI-DSF, Transparency, GMLP, EU AI Act, ISO 42001) | **Must 부분 P0** / Should 부분 P1 (AI 배포 의존) |
+| **SPEC-XPE-SEC** | M-04 (§524B), M-05 (SBOM), M-06 (Vuln Mgmt), M-07 (Input Val) | S-SEC-01 (SLSA L3), S-SEC-05 (IEC 81001-5-1), 기존 S-SEC-02~04 | **Must 부분 P0** / Should 부분 P1 |
+| **SPEC-XPE-IOP** | M-08 (DICOM), M-09 (Conformance) | S-IOP-01 (DICOMweb), S-IOP-02 (FHIR R5), S-IOP-03 (AIR/AIRA), S-IOP-05 (IHE Baseline) | **Must 부분 P0** / Should 부분 P2 |
+| **SPEC-XPE-OPS** | M-10 (PMS) | S-OPS-01 (Drift), S-OPS-02 (OTEL), S-OPS-05 (Reproducible) 등 | **Must 부분 P0** / Should 부분 P1-P2 |
+
+### 5.2 전략적 결론
+
+**Must 부분은 즉시 착수** (4개 SPEC 합계 12개 Must 항목). **Should 부분은 Phase 연결 조건부**:
+- S-REG-03~06 (AI 관련 규제): Phase 3 AI-DSF 배포 승인 시 Must 승격
+- S-REG-07 (EU AI Act): EU + AI 판매 결정 시 Must 승격
+- S-IOP-01~03: Phase 2-3 상호운용성 고도화 단계
+- S-AI-06~08: AI 구현 시작 시
+
+### 5.3 주의: SPEC frontmatter 재조정
+
+신규 4 SPEC의 `priority` 필드는 v1.1에서 다음과 같이 재조정:
+- **SPEC-XPE-REG**: `priority: Must (M-01~M-03 base) + Should (AI 관련)` 혼합
+- **SPEC-XPE-SEC**: `priority: Must (M-04~M-07) + Should (L3 확장)` 혼합
+- **SPEC-XPE-IOP**: `priority: Must (M-08, M-09 DICOM 핵심) + Should (DICOMweb, FHIR, IHE)` 혼합
+- **SPEC-XPE-OPS**: `priority: Must (M-10 PMS) + Should (OTEL/Drift/Reproducible)` 혼합
+
+### 5.2 기존 문서 업그레이드
+
+| 문서 | 현재 | 목표 | 주요 변경 |
+|------|:----:|:----:|----------|
+| SPEC-XPE-MASTER | v2.0.0 | **v3.0.0** | 6개 신규 축 통합, Model Observer Quality Gate, Must/Should/Could 매트릭스 |
+| score-improvement-plan | v2.0.0 | **v3.0.0** | 85 → 95 경로, Framework C (Future-Value) 신설 |
+| sprint-roadmap | v2.0.0 | **v3.0.0** | 11 → 14 sprints (S-REG, S-SEC, S-IOP, S-OPS 추가) |
+| tech.md | v1.0 | **v2.0** | ONNX 1.20+, SBOM 도구, CMake Presets v6, SLSA L3 |
+| product.md | v1.0 | **v2.0** | 2026 규제 환경 + Must/Should/Could 전략 |
+| 신규 SPEC-XPE-P3-AI | 없음 | **v1.0** | SSL + Diffusion + XAI + Conformal UQ + PCCP 연계 |
+
+---
+
+## 6. 채택 결정 매트릭스
+
+### 6.1 Must 항목 (즉시 채택, 반론 없음)
+
+27 Must 항목 전체: 법률 의무 또는 프로젝트 기본 요건 → **무조건 채택**.
+
+### 6.2 Should 항목 평가
+
+| ID | 품질 upside | 구현 가능성 | 증거 강도 | 규제 경계 | 결정 |
+|----|:-----------:|:----------:|:--------:|:---------:|:----:|
+| S-REG-01 NIST AI RMF Profile | 중 | 중 | 중 | 낮음 | **부분 채택** |
+| S-REG-02 Bias/Fairness | 높음 | 중 | 높음 | 낮음 | **채택** |
+| S-SEC-01 SLSA L3 | 높음 | 중 | 높음 | 낮음 | **채택** |
+| S-SEC-02 EMB3D Threat Model | 높음 | 높음 | 높음 | 낮음 | **채택** |
+| S-SEC-03 SBOM Continuous | 높음 | 높음 | 높음 | 낮음 | **채택** |
+| S-SEC-04 CVD Process | 중 | 높음 | 중 | 낮음 | **채택** |
+| S-IOP-01 DICOMweb | 높음 | 중 | 높음 | 낮음 | **채택 (Phase 2)** |
+| S-IOP-02 FHIR R5 | 중상 | 중 | 높음 | 낮음 | **채택 (Phase 2-3)** |
+| S-IOP-03 IHE AIR/AIRA | 높음 | 중 | 높음 | 낮음 | **채택 (Phase 3)** |
+| S-IOP-04 DICOM SR for AI | 중 | 높음 | 높음 | 낮음 | **채택** |
+| S-AI-01 SSL Denoising | 높음 | 중 | 높음 | 낮음 | **채택 (benchmark gate)** |
+| S-AI-02 Diffusion Priors | 높음 | 중하 | 높음 | 중 | **채택 (opt-in premium)** |
+| S-AI-03 XAI Sidecar | 중 | 높음 | 중상 | 중(post-hoc misleading) | **제한적 채택** |
+| S-AI-04 Conformal UQ | 중상 | 중 | 높음 | 낮음 | **채택** |
+| S-AI-05 ONNX 1.20+ | 높음 | 높음 | 높음 | 낮음 | **즉시 채택** |
+| S-OPS-01 Drift Detection | 높음 | 중 | 높음 | 낮음 | **채택** |
+| S-OPS-02 OpenTelemetry | 중 | 높음 | 중 | 낮음 | **채택 (opt-in)** |
+| S-OPS-03 Reject-Analysis | 높음 | 높음 | 높음 | 낮음 | **채택** |
+| S-OPS-04 VEX Automation | 중상 | 중 | 높음 | 낮음 | **채택** |
+
+**Should 채택율: 19/19 (전체 채택, 일부 조건부)**
+
+### 6.3 Could 항목 — Phase 4+ 또는 연구 모드
+
+모든 Could 항목은 **Phase 4 Research Track** 또는 **Post-Market Evolution** 로 보류.
+
+---
+
+## 7. 업그레이드 점수 영향 (Framework Reconciliation, v1.1 엄격)
+
+### 7.1 Framework A (Process/Compliance) 영향 (v1.1 재계산)
+
+Must가 12개로 축소되어 "Must 완료 시" 기여가 감소. 하지만 Should가 35개로 확장되어 "Must+Should 완료 시" 점수는 유사하게 유지.
+
+| 영역 | 현재 | Must (12) 완료 | Must + 주요 Should 완료 | Must + 전체 Should |
+|------|:----:|:-------------:|:----------------------:|:-------------------:|
+| 요구사항 완전성 | 13 | 18 | 23 | 25 |
+| 문서 품질 | 17 | 18 | 19 | 20 |
+| 아키텍처 설계 | 17 | 18 | 19 | 20 |
+| 구현 진행도 | 6 | 12 | 17 | 19 |
+| 품질 보증 | 8 | 10 | 13 | 14 |
+| **합계** | **61** | **76** (was 87) | **91** | **98** |
+
+**핵심**: Must만 완료해도 76점 달성 (블로커 해소), 주요 Should (Phase별 관련)까지 완료 시 91점, 전체 Should까지 98점.
+
+### 7.2 Framework B (Product/Delivery) 영향 (v1.1 재계산)
+
+| 영역 | 현재 | Must (12) 완료 | Must + 주요 Should 완료 | Must + 전체 Should |
+|------|:----:|:-------------:|:----------------------:|:-------------------:|
+| 기능 범위 | 26 | 28 | 31 | 34 |
+| 성능·메모리 | 12 | 12 | 13 | 14 |
+| 알고리즘 품질 | 11 | 12 | 15 | 18 |
+| 규제·문서 | 9 | 12 | 14 | 15 |
+| 운영 준비도 | 8 | 10 | 12 | 14 |
+| **합계** | **66** | **74** (was 85) | **85** | **95** |
+
+**핵심**: Must만으로 74점(블로커 해소 + 출시 가능 상태), 주요 Should까지 85점이 현실적 목표.
+
+### 7.3 Framework C (Future-Value) 신설 제안
+
+Could 항목의 옵션 가치 평가용 신규 프레임워크.
+
+| 영역 | 가중 | 배점 |
+|------|:----:|:---:|
+| AI Foundation Readiness | 25 | MedSAM/Federated 실험 인프라 |
+| Deployment Flexibility | 20 | GPU/WASM/Rust 대안 경로 |
+| Long-term Security | 20 | PQC, Zero-trust 준비 |
+| Advanced Interoperability | 15 | FHIRcast, breakthrough profiles |
+| Research Velocity | 20 | Continuous learning, online UQ |
+| **합계** | **100** | 현재 15, 목표 60+ (2027) |
+
+---
+
+## 8. 실행 순서 (Sprint Dependency, v1.1 우선순위 재조정)
+
+```
+기존 Critical Path: S0-A → S0-B → S1-A → S1-B1 → S2-A → S3
+                                  │
+신규 Parallel:  ───┬── S-REG-CORE (M-01, M-02, M-03 base docs) ── 즉시 착수
+                   ├── S-SEC-CORE (M-04, M-05, M-06, M-07)    ── S0-B 후 병행
+                   ├── S-IOP-CORE (M-08, M-09 DICOM base)     ── S1-B3 후 병행
+                   └── S-OPS-CORE (M-10 PMS)                  ── S1-B1 후 병행
+
+ Phase 3 진입 시 Should 부분 승격:
+               ── S-REG-AI (S-REG-03~07 PCCP/GMLP 등): Phase 3 승인 후
+               ── S-IOP-EXT (DICOMweb/FHIR/IHE AIR): Phase 2-3 필요 시
+```
+
+**v1.1 착수 우선순위** (Must 비중 기반):
+
+**Wave P0 (즉시, Must만)**:
+1. **S-REG-CORE** (Must 3개): IEC 62304 + EU MDR + 21 CFR baseline 문서
+2. **S-SEC-CORE** (Must 4개): §524B + SBOM + Vuln Mgmt + Input Val (S0-B 후)
+3. **S-OPS-CORE** (Must 1개): PMS Plan + 보고 체계 (S1-B1 후)
+4. **S-IOP-CORE** (Must 2개): DICOM 3.0 + Conformance Statement (S1-B3 후)
+
+**Wave P1 (Should 일부, 조건부)**:
+5. **S-SEC-EXT** (Should): SLSA L2→L3, IEC 81001-5-1 통합
+6. **S-OPS-EXT** (Should): OTEL, Drift Detection, Reproducible
+
+**Wave P2 (Phase 확장 시)**:
+7. **S-IOP-EXT** (Should): DICOMweb, FHIR R5, IHE (Phase 2 상호운용성 확장 결정 시)
+8. **S-REG-AI** (Should): FDA PCCP, GMLP, Transparency (Phase 3 AI 착수 시)
+9. **S-REG-EU-AI** (Should): EU AI Act (EU+AI 판매 결정 시)
+10. **S-AI-GOV**: Model Card, Data Lineage, Deterministic Fallback (AI 구현 시)
+
+**핵심 차이**: v1.0에서는 모든 4개 SPEC이 P0 (즉시)였으나, v1.1에서는 각 SPEC이 **core(Must)** 부분만 P0, **extension(Should)** 부분은 Phase 연결 조건부 진행.
+
+---
+
+## 9. 리스크 및 완화
+
+| 리스크 | 완화책 |
+|--------|-------|
+| 신규 SPEC 4종 동시 진행으로 스코프 폭발 | EARS 요구사항 수 상한: REG ≤45, SEC ≤40, IOP ≤35, OPS ≤35 |
+| 기존 Phase 1a 지연 | 신규 SPEC은 Phase 1a와 병행 가능 (문서 선행, 구현 후행) |
+| AI 축 과도 투입 | Must만 Phase 1~2에 강제, Should는 Phase 3 |
+| 규제 해석 오류 | 법률 자문 검토 체크포인트 5개 설정 (각 SPEC sign-off) |
+| Foundation Model governance 미확립 | Could 티어로 격리, Phase 4 연구 모드 |
+
+---
+
+## 10. 참고 문헌 (Primary Sources)
+
+### 10.1 Regulatory
+
+- [FDA PCCP Final Guidance (2024-12)](https://www.fda.gov/regulatory-information/search-fda-guidance-documents/marketing-submission-recommendations-predetermined-change-control-plan-artificial-intelligence)
+- [FDA AI-DSF Lifecycle Draft (2025-01)](https://www.fda.gov/regulatory-information/search-fda-guidance-documents/artificial-intelligence-enabled-device-software-functions-lifecycle-management-and-marketing)
+- [FDA Transparency for ML MD (2024-06)](https://www.fda.gov/medical-devices/software-medical-device-samd/transparency-machine-learning-enabled-medical-devices-guiding-principles)
+- [IMDRF GMLP N88 Final (2025-01)](https://www.imdrf.org/documents/good-machine-learning-practice-medical-device-development-guiding-principles)
+- [EU AI Act Annex III](https://artificialintelligenceact.eu/annex/3/)
+- [EU MDR 2017/745](https://eumdr.com/)
+- [ISO/IEC 42001:2023](https://www.iso.org/standard/42001)
+
+### 10.2 Cybersecurity
+
+- [FDA Cybersecurity Final (2025-06)](https://www.federalregister.gov/documents/2025/06/27/2025-11669/cybersecurity-in-medical-devices-quality-system-considerations-and-content-of-premarket-submissions)
+- [IEC 81001-5-1 Standard](https://www.iso.org/standard/76097.html)
+- [SLSA Specification](https://slsa.dev/spec/v1.0/levels)
+- [SPDX Specification](https://spdx.dev/)
+- [CycloneDX Specification](https://cyclonedx.org/)
+- [MITRE EMB3D](https://emb3d.mitre.org/)
+- [MDIC Threat Modeling Playbook](https://www.mitre.org/sites/default/files/2021-11/Playbook-for-Threat-Modeling-Medical-Devices.pdf)
+
+### 10.3 Interoperability
+
+- [DICOM Standard](https://www.dicomstandard.org/)
+- [DICOMweb Explained](https://en.wikipedia.org/wiki/DICOMweb)
+- [FHIR R5 ImagingStudy](https://www.hl7.org/fhir/imagingstudy.html)
+- [FHIR R5 ImagingSelection](https://hl7.org/fhir/R5/imagingselection.html)
+- [IHE RAD Technical Framework](https://www.ihe.net/resources/technical_frameworks/)
+- [IHE AI Results Assessment](https://www.ihe.net/uploadedFiles/Documents/Radiology/IHE_RAD_Suppl_AIRA.pdf)
+
+### 10.4 AI/ML Research
+
+- [MedSAM (Nature Comms 2024)](https://www.nature.com/articles/s41467-024-44824-z)
+- [Diffusion Priors Zero-Shot LDCT (MP 2025)](https://aapm.onlinelibrary.wiley.com/doi/10.1002/mp.17431)
+- [NEED — Noise-Inspired Diffusion (2025)](https://www.sciencedirect.com/science/article/abs/pii/S1361841525002579)
+- [Distribution Shift Detection (Nature Digital Med 2024)](https://www.nature.com/articles/s41746-024-01085-w)
+- [Empirical Data Drift Detection (Nature Comms 2024)](https://www.nature.com/articles/s41467-024-46142-w)
+- [ONNX Runtime](https://onnxruntime.ai/)
+- [Conformal Prediction Medical AI](https://pubmed.ncbi.nlm.nih.gov/39375270/)
+
+### 10.5 Standards Bodies
+
+- NEMA (DICOM), HL7 (FHIR), IHE International, IMDRF, NIST, FDA CDRH, EMA
+- IEEE, IEC TC 62A, ISO TC 215, OASIS (CycloneDX), Linux Foundation (SPDX, SLSA)
+
+---
+
+**끝. 이 문서는 SPEC-XPE-MASTER v3.0.0의 normative input이며, 4개 신규 SPEC(REG/SEC/IOP/OPS)의 근거 문서이다.**

--- a/.moai/specs/SPEC-XPE-IOP/spec.md
+++ b/.moai/specs/SPEC-XPE-IOP/spec.md
@@ -1,0 +1,307 @@
+# SPEC-XPE-IOP: Interoperability Master
+
+---
+id: SPEC-XPE-IOP
+version: 1.1.0
+status: Draft
+created: 2026-04-17
+updated: 2026-04-17
+author: MoAI (manager-spec orchestration)
+priority: Mixed (Must for M-08, M-09 DICOM core; Should for DICOMweb/FHIR R5/IHE)
+issue_number: null
+iec62304_class: B
+development_mode: TDD
+sprint: S-IOP-CORE (Must) + S-IOP-EXT (Should, Phase 2-3 상호운용 확장)
+dependency: SPEC-XPE-MASTER v3.0.0, SPEC-XPE-P1B-DICOM (S1-B3) 선행, trend-survey-2026.md v1.1
+---
+
+## Priority Reclassification Notice (v1.1)
+
+본 SPEC의 우선순위는 trend-survey-2026.md v1.1 엄격 재분류에 따라 혼합:
+
+- **Must (즉시, 시장 진입 블로커)**: DICOM 3.0 Core Conformance (M-08), DICOM Conformance Statement 발행 (M-09)
+- **Should (강력 권장, 조건부)**: DICOMweb (WADO-RS/STOW-RS/QIDO-RS), FHIR R5 ImagingStudy/ImagingSelection, IHE RAD Profiles (SWF.b/PDI/PIR baseline + AIR/AIRA for AI), DICOM SR for AI output
+- **강등 근거**: DICOM 핵심만 있으면 병원 PACS 통합 가능. DICOMweb/FHIR/IHE는 통합 편의성·현대성 증진이나 블로커 아님
+- **현재 실행 범위**: Must 부분만 즉시, DICOMweb/FHIR은 Phase 2 확장 결정 시, IHE AIR/AIRA는 Phase 3 AI 시
+
+## HISTORY
+
+| Version | Date       | Author       | Changes                                   |
+|---------|------------|--------------|-------------------------------------------|
+| 1.0.0   | 2026-04-17 | MoAI         | Initial EARS SPEC integrating DICOM 3.0 + DICOMweb + FHIR R5 + IHE RAD (SWF.b/PDI/AIR/AIRA) |
+
+---
+
+## 1. Scope
+
+### 1.1 Overview
+
+본 SPEC은 XPE의 **상호운용성 마스터 문서**로서, 병원 PACS/EMR/RIS 통합을 위한 4개 표준 스택을 정의한다:
+
+1. **DICOM 3.0** (Must, 기존 xpe_dicom.dll 확장)
+2. **DICOMweb** (Should, WADO-RS / STOW-RS / QIDO-RS REST 추가)
+3. **FHIR R5 ImagingStudy + ImagingSelection** (Should, HL7 연동)
+4. **IHE Radiology Profiles** (Must 3 프로필 + Should 2 프로필)
+
+본 SPEC은 기존 SPEC-XPE-P1B-DICOM(S1-B3)을 확장하고, xpe_dicom.dll 및 새로운 인터페이스 모듈(선택적 xpe_interop.dll)을 정의한다.
+
+### 1.2 In Scope
+
+- DICOM Conformance Statement 발행
+- DICOMweb 클라이언트 및 서버 구현 (옵션)
+- FHIR R5 ImagingStudy/Selection 어댑터
+- IHE RAD Profile: SWF.b, PDI, PIR (Must)
+- IHE RAD Profile: AIR, AIRA (Should, AI 결과)
+- DICOM SR for AI output (JSON representation)
+- HL7 FHIR Observation 매핑
+
+### 1.3 Exclusions
+
+- Full PACS server implementation (only client-side + optional server façade)
+- FHIR R5 outside ImagingStudy/ImagingSelection/Observation resources
+- XDS-I.b implementation (referenced for future, Could tier)
+- FHIRcast real-time sync (Could tier)
+- Non-radiology IHE domains
+
+---
+
+## 2. Referenced Documents
+
+| Document ID | Title | Version | Role |
+|-------------|-------|---------|------|
+| DICOM-PS3 | DICOM Standard PS 3.1-3.20 | 2025b current | Normative |
+| DICOM-PS3.18 | DICOM PS 3.18 Web Services | 2025b | Normative (DICOMweb) |
+| DICOM-PS3.2 | DICOM PS 3.2 Conformance | 2025b | Normative |
+| HL7-FHIR-R5 | Fast Healthcare Interoperability Resources R5 | 5.0.0 | Normative |
+| HL7-IMG-R5 | ImagingStudy + ImagingSelection | R5 | Normative |
+| IHE-RAD-TF | IHE Radiology Technical Framework | Rev 23.0 (2025-08-08) | Normative |
+| IHE-RAD-AIR | AI Results | Suppl | Normative (Should) |
+| IHE-RAD-AIRA | AI Result Assessment | Suppl (2025-06-12) | Normative (Should) |
+| SPEC-XPE-P1B-DICOM | DICOM module | v1.0 | Upstream |
+| SPEC-XPE-MASTER | XPE Master | v3.0.0 | Upstream |
+
+---
+
+## 3. Definitions
+
+| Term | Definition |
+|------|-----------|
+| DICOMweb | RESTful DICOM services (PS 3.18) |
+| WADO-RS | Web Access to DICOM Objects - RESTful Services |
+| STOW-RS | Store Over The Web - RESTful Services |
+| QIDO-RS | Query based on ID for DICOM Objects - RESTful Services |
+| UPS-RS | Unified Procedure Step - RESTful Services (partial support only in vendors 2025) |
+| FHIR | Fast Healthcare Interoperability Resources |
+| ImagingStudy | FHIR resource for DICOM study (Maturity Level 4 in R5) |
+| ImagingSelection | FHIR resource for subset of study (R5 new) |
+| SOP | Service-Object Pair (DICOM) |
+| IHE | Integrating the Healthcare Enterprise |
+| SWF.b | Scheduled Workflow (b revision) IHE RAD |
+| PDI | Portable Data for Imaging |
+| PIR | Patient Information Reconciliation |
+| AIR | AI Results (IHE) |
+| AIRA | AI Result Assessment (IHE, 2025-06) |
+| SR | Structured Report |
+
+---
+
+## 4. Requirements (EARS Format)
+
+### 4.1 DICOM 3.0 Core (Must · 기존 유지/강화)
+
+**REQ-IOP-001** (Ubiquitous): The XPE xpe_dicom.dll shall implement DICOM 3.0 Part 5 (Data Structures and Encoding), Part 6 (Data Dictionary), and Part 10 (Media Storage and File Format).
+
+**REQ-IOP-002** (Ubiquitous): Supported SOP Classes shall include at minimum: Digital X-Ray Image Storage - For Presentation (1.2.840.10008.5.1.4.1.1.1.1), Digital X-Ray Image Storage - For Processing (1.2.840.10008.5.1.4.1.1.1.1.1), Grayscale Softcopy Presentation State Storage (1.2.840.10008.5.1.4.1.1.11.1).
+
+**REQ-IOP-003** (Ubiquitous): Supported Transfer Syntaxes shall include at minimum: Explicit VR Little Endian (1.2.840.10008.1.2.1), JPEG Lossless Non-Hierarchical 14 (1.2.840.10008.1.2.4.57), JPEG 2000 Lossless Only (1.2.840.10008.1.2.4.90).
+
+**REQ-IOP-004** (Ubiquitous): DICOM Network Services shall support SCU and SCP roles for C-STORE, C-FIND, C-ECHO.
+
+**REQ-IOP-005** (Ubiquitous): A DICOM Conformance Statement per PS 3.2 shall be published with each release identifying supported SOP Classes, Transfer Syntaxes, and extensions.
+
+### 4.2 DICOMweb (Should · Phase 2)
+
+**REQ-IOP-010** (Ubiquitous): The xpe_interop module (new) SHALL implement DICOMweb Client per PS 3.18.
+
+**REQ-IOP-011** (Ubiquitous): WADO-RS shall support: retrieveStudy, retrieveSeries, retrieveInstance, retrieveFrames, retrieveBulkdata, retrieveMetadata.
+
+**REQ-IOP-012** (Ubiquitous): STOW-RS shall support: storeInstances with multipart/related (application/dicom).
+
+**REQ-IOP-013** (Ubiquitous): QIDO-RS shall support: searchForStudies, searchForSeries, searchForInstances with query parameter filters.
+
+**REQ-IOP-014** (Event-driven): When DICOMweb server returns JSON media type (application/dicom+json), the client shall parse using DICOM JSON representation per PS 3.18 Annex F.
+
+**REQ-IOP-015** (Event-driven): When HTTP 429 (Too Many Requests) or 503 (Service Unavailable) is received, the client shall implement exponential backoff retry with max 3 attempts.
+
+**REQ-IOP-016** (Ubiquitous): DICOMweb transport shall support HTTPS with TLS 1.2+ (cross-reference SPEC-XPE-SEC §4.8).
+
+**REQ-IOP-017** (Ubiquitous): DICOMweb authentication shall support Basic Auth (testing), Bearer Token (OAuth 2.0), and optional mTLS.
+
+### 4.3 FHIR R5 (Should · Phase 2-3)
+
+**REQ-IOP-020** (Ubiquitous): The xpe_interop module SHALL provide FHIR R5 ImagingStudy resource generation from DICOM study metadata.
+
+**REQ-IOP-021** (Ubiquitous): ImagingStudy resource shall populate: subject (Patient reference), started, numberOfSeries, numberOfInstances, modality, series[*], series[*].instance[*].
+
+**REQ-IOP-022** (Ubiquitous): ImagingSelection resource generation SHALL be supported when AI output identifies a ROI or specific frames.
+
+**REQ-IOP-023** (Ubiquitous): FHIR Observation resource generation SHALL map DICOM Structured Report (SR) AI outputs following HL7 Imaging Integration mapping guide.
+
+**REQ-IOP-024** (Ubiquitous): FHIR transport shall support Content-Type application/fhir+json and application/fhir+xml.
+
+**REQ-IOP-025** (Ubiquitous): FHIR operations supported: create, read, search (patient scoped).
+
+### 4.4 IHE Radiology Profiles
+
+#### 4.4.1 SWF.b (Must)
+
+**REQ-IOP-030** (Ubiquitous): The XPE system shall participate in IHE Scheduled Workflow (SWF.b) as Image Manager / Image Archive actor for the image management transactions.
+
+**REQ-IOP-031** (Ubiquitous): The system shall support Modality Images Stored (RAD-8) transaction.
+
+**REQ-IOP-032** (Ubiquitous): The system shall support Query Images (RAD-14) and Retrieve Images (RAD-16) transactions.
+
+#### 4.4.2 PDI (Must)
+
+**REQ-IOP-040** (Ubiquitous): The XPE system shall support Portable Data for Imaging (PDI) profile as Portable Media Creator or Importer.
+
+**REQ-IOP-041** (Ubiquitous): PDI media shall conform to DICOM Part 10 file format with DICOMDIR indexing.
+
+#### 4.4.3 PIR (Must)
+
+**REQ-IOP-050** (Ubiquitous): The XPE system shall support Patient Information Reconciliation (PIR) for demographic corrections propagated from Patient Demographics Supplier actor.
+
+#### 4.4.4 AIR (Should)
+
+**REQ-IOP-060** (Ubiquitous): The XPE system SHALL participate in IHE AI Results (AIR) profile as AI Model Producer.
+
+**REQ-IOP-061** (Ubiquitous): AI outputs from POST-09 Bone Suppression, POST-07 AI Collimation, PRE-06 ML Defect shall be encoded per AIR transaction requirements.
+
+**REQ-IOP-062** (Ubiquitous): AI output encoding shall use DICOM SR, Segmentation, or Parametric Map as appropriate per AI Model type.
+
+#### 4.4.5 AIRA (Should)
+
+**REQ-IOP-070** (Ubiquitous): The XPE system SHALL support IHE AI Result Assessment (AIRA, 2025-06-12) profile for clinical user assessment feedback of AI outputs.
+
+**REQ-IOP-071** (Ubiquitous): AIRA transaction shall record: user ID, assessment value (accepted/modified/rejected), rationale, timestamp.
+
+**REQ-IOP-072** (Event-driven): When an AI output is assessed, the system shall persist AIRA record per site data retention policy.
+
+### 4.5 DICOM SR for AI Output
+
+**REQ-IOP-080** (Ubiquitous): AI module outputs shall be encodable as DICOM Structured Reports using templates consistent with DICOM Working Group 21 AI guidelines.
+
+**REQ-IOP-081** (Ubiquitous): AI-generated SR shall include: model identifier, model version, confidence score, saliency reference (if enabled per SPEC-XPE-REG §4.3), timestamp, input image reference.
+
+**REQ-IOP-082** (Ubiquitous): SR encoding shall support JSON representation per DICOM Supplement (JSON Representation of Structured Reports) for easier integration with modern workflows.
+
+### 4.6 Patient Privacy and De-identification
+
+**REQ-IOP-090** (Ubiquitous): DICOMweb exports SHALL support DICOM PS 3.15 de-identification profile selection.
+
+**REQ-IOP-091** (Ubiquitous): FHIR export SHALL NOT include PHI beyond what is explicitly required for the clinical use case.
+
+### 4.7 Testing and Validation
+
+**REQ-IOP-100** (Ubiquitous): The system SHALL participate in annual IHE Connectathon for SWF.b, PDI, PIR validation.
+
+**REQ-IOP-101** (Ubiquitous): DICOM Conformance SHALL be validated using dcm4che tools (dcm4chee, dcmqrscp).
+
+**REQ-IOP-102** (Ubiquitous): FHIR conformance SHALL be validated using HL7 FHIR Validator (Java).
+
+---
+
+## 5. Acceptance Criteria
+
+### 5.1 Conformance Statements
+
+- [ ] DICOM Conformance Statement v1.0 published (PS 3.2 format)
+- [ ] DICOMweb Conformance document (list of supported operations)
+- [ ] FHIR CapabilityStatement resource for supported operations
+- [ ] IHE Integration Profile Statement for SWF.b + PDI + PIR
+
+### 5.2 Code Artifacts
+
+- [ ] xpe_dicom.dll passes dcm4che conformance test suite
+- [ ] xpe_interop.dll (new) implements DICOMweb client with ≥ 85% test coverage
+- [ ] FHIR ImagingStudy resource generator with unit tests
+- [ ] AI SR encoder with test fixtures for each AI module
+
+### 5.3 Connectathon Readiness
+
+- [ ] Tested against dcm4chee test instance
+- [ ] Tested against Orthanc test server
+- [ ] Tested against AWS HealthImaging demo endpoint
+
+### 5.4 Documentation
+
+- [ ] Integration guide for hospital IT
+- [ ] SDK samples (C#, Python) for DICOMweb client
+
+---
+
+## 6. Out-of-Scope Clarifications
+
+- XDS-I.b cross-enterprise sharing → Future Could
+- FHIRcast real-time sync → Future Could
+- Full FHIR server implementation → out of scope (client/adapter only)
+- Non-imaging FHIR resources beyond minimal Patient/Observation → out of scope
+
+---
+
+## 7. Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|:--------:|-----------|
+| DICOM Conformance gaps discovered late | Medium | Early Connectathon prep, automated test suite |
+| DICOMweb endpoint performance issues | Medium | Benchmark harness, retry/backoff implementation |
+| FHIR R5 version divergence with EHR vendors (still on R4) | Medium | Support both R4 and R5 capability statements |
+| PHI leak via FHIR exports | High | Strict de-identification validation; audit on export |
+| IHE AIRA profile newness (2025-06) | Medium | Monitor IHE Connectathon 2026 for early adopters |
+
+---
+
+## 8. Deliverables
+
+### 8.1 Documents (8)
+
+1. `docs/interop/dicom-conformance-statement.md`
+2. `docs/interop/dicomweb-conformance.md`
+3. `docs/interop/fhir-capability-statement.md`
+4. `docs/interop/ihe-integration-statement.md`
+5. `docs/interop/ai-sr-encoding-guide.md`
+6. `docs/interop/integration-guide-for-it.md`
+7. `docs/interop/fhir-observation-mapping.md` — DICOM SR → FHIR
+8. `docs/interop/hospital-connectathon-runbook.md`
+
+### 8.2 Code Modules
+
+- `modules/dicom/` (existing, enhanced per §4.1)
+- `modules/interop/` (new, contains DICOMweb client + FHIR adapter)
+  - `xpe_interop.dll` Layer 1 (no lateral deps)
+  - ~10-12 API functions (REST, FHIR)
+- SDK samples: `samples/dicomweb-csharp/`, `samples/fhir-python/`
+
+### 8.3 RTM Entries
+
+- 30+ REQ-IOP-XXX entries mapped to SWU-interop.*
+
+---
+
+## 9. Dependencies
+
+- **Upstream**: SPEC-XPE-P1B-DICOM v1.0 (S1-B3), SPEC-XPE-MASTER v3.0.0, SPEC-XPE-P3-AI (for AI SR)
+- **Downstream**: SPEC-XPE-OPS (telemetry of interop operations)
+- **External**: dcm4che (Java library) test setup, Orthanc reference server, HAPI FHIR
+
+---
+
+## 10. Change Control
+
+- DICOM standard updates (annual): review every Q1
+- IHE TF updates (semi-annual): review at publication
+- FHIR R6 ballot: monitor
+
+---
+
+**본 SPEC은 XPE의 상호운용성 마스터로서 2026+ PACS/EMR 현대화 환경에서 XPE를 네트워크 일원으로 통합한다.**

--- a/.moai/specs/SPEC-XPE-MASTER/score-improvement-plan-v3.md
+++ b/.moai/specs/SPEC-XPE-MASTER/score-improvement-plan-v3.md
@@ -1,0 +1,285 @@
+# XPE Score Improvement Plan v3.0.0 (61 → 85 → 95)
+
+**Document ID**: SCORE-PLAN-001
+**Version**: 3.0.0
+**Date**: 2026-04-17
+**Status**: Active (Supersedes v2.0.0)
+**Relationship**: Extends `score-improvement-plan-85.md` (v2.0.0) with 85→95 path, Framework C, and Must/Should/Could gating
+**Sources**:
+- score-improvement-plan-85.md v2.0.0 (retained baseline)
+- `.moai/project/trend-survey-2026.md` v1.0.0 (normative input)
+- SPEC-XPE-MASTER v3.0.0 addendum
+
+---
+
+## Changelog (v2.0.0 → v3.0.0, v3.1 Strict Reclassification)
+
+| Change | Detail |
+|--------|--------|
+| 85 → 95 path added | 8-step roadmap beyond 85, driven by Should tier adoption |
+| Framework C (Future-Value) introduced | Could tier evaluation, 2027+ horizon |
+| Must/Should/Could gating | 모든 점수 이동에 티어 게이트 적용 |
+| Regulatory scoring reweighted | FDA PCCP + EU AI Act + ISO 42001 가산점 |
+| Security scoring reweighted | SBOM + SLSA + threat model 가산점 |
+| Post-market scoring | Drift + OTEL + VEX 운영 준비도 |
+| **v3.1 Strict Must** | **Must 27→12로 축소. 이에 따라 Must-only 점수 85→76, Must+major-Should 목표 85 재설정.** 엄격 기준 채택 반영 |
+
+---
+
+## 1. Three-Framework System (v3.0)
+
+### 1.1 Framework A (Process/Compliance) — REWEIGHTED
+
+| 영역 | v2.0 배점 | v3.0 배점 | 변경 사유 |
+|------|:--------:|:--------:|-----------|
+| 요구사항 완전성 (EARS) | 25 | **25** | 유지 |
+| 문서 품질 (IEC 62304) | 20 | **18** | -2 (규제 일부 이전) |
+| 아키텍처 설계 | 20 | **18** | -2 (Must arch 일부 이전) |
+| 구현 진행도 | 20 | **17** | -3 (AI governance 포함 가능 이전) |
+| 품질 보증 | 15 | **12** | -3 (보안/운영 이전) |
+| **NEW: 규제 준수** | — | **5** | FDA/EU/ISO |
+| **NEW: 사이버보안** | — | **3** | FDA §524B |
+| **NEW: 운영 준비도** | — | **2** | PMS, drift |
+| **합계** | 100 | **100** | 재분배 |
+
+### 1.2 Framework B (Product/Delivery) — REWEIGHTED
+
+| 영역 | v2.0 배점 | v3.0 배점 |
+|------|:--------:|:--------:|
+| 기능 범위 | 35 | **30** |
+| 성능·메모리 | 15 | **13** |
+| 알고리즘 품질 | 20 | **17** |
+| 규제·문서 | 15 | **15** |
+| 운영 준비도 | 15 | **15** |
+| **NEW: 상호운용성** | — | **5** |
+| **NEW: AI governance** | — | **5** |
+| **합계** | 100 | **100** |
+
+### 1.3 Framework C (Future-Value) — NEW
+
+Could 티어와 2027+ 대비 전략적 옵션 가치 측정.
+
+| 영역 | 배점 | 평가 기준 |
+|------|:---:|-----------|
+| AI Foundation Readiness | 25 | MedSAM/Federated/Foundation model 실험 인프라 |
+| Deployment Flexibility | 20 | GPU/WASM/Rust 대안 경로 준비 |
+| Long-term Security | 20 | PQC, Zero-trust 로드맵 |
+| Advanced Interoperability | 15 | FHIRcast, breakthrough IHE 프로필 |
+| Research Velocity | 20 | Continuous experiment, UQ 고도화 |
+| **합계** | 100 | 현재 ~15, 목표 60+ (2027) |
+
+---
+
+## 2. Consolidated Targets (v3.1 Strict)
+
+**v3.1 변경**: Must가 12개로 축소됨에 따라 "Must 완료" 단독 점수는 76점(블로커 해소 상태). 목표 85점은 Must + 주요 Should(Phase 연결 관련) 완료가 필요하며, 이를 "Milestone 1-Extended"로 명명.
+
+| Marker | Framework A | Framework B | Framework C | 정의 |
+|:------:|:-----------:|:-----------:|:-----------:|------|
+| 현재 (2026-04-17) | 61 | (Phase 1b 완료 시 66) | 15 | 출발점 |
+| **Milestone 1 (Must 12 완료)** | **76** (was 85) | **74** (was 85) | 20 | 출시 블로커 해소 (법적 최소) |
+| **Milestone 1-Ext (Must + 주요 Should)** | **85** | **85** | 30 | 목표 85 = Must + Phase 연결 Should |
+| **Milestone 2 (+ 전체 Should)** | **95** | **95** | 45 | 현대적·경쟁력 |
+| **Milestone 3 (+ 선별 Could)** | 98 | 98 | 65 | 연구 모드 |
+| Long-term (2027+) | 100 | 100 | 80+ | Phase 4 |
+
+### 주요 Should (Milestone 1-Ext 85점 달성 조건)
+
+- S-QUAL-01 (TRUST 5) — 프로젝트 baseline
+- S-QUAL-02 (Reference+SIMD Parity) — 품질 기반
+- S-QUAL-03 (MX Tag), S-QUAL-04 (Anti-Spaghetti) — 아키텍처
+- S-SEC-01 (SLSA L2→L3), S-SEC-05 (IEC 81001-5-1) — 보안 권장
+- S-OPS-05 (Reproducible Builds) — SBOM 전제
+
+AI 관련 Should (S-REG-03~07, S-AI-06~08)는 Phase 3 진입 결정 시 개별 승격.
+
+---
+
+## 3. Path Breakdown (v3.1 Strict)
+
+### 3.1 Path 1: 61 → 76 (Must 12만 완료, 블로커 해소)
+
+| 단계 | 행동 | A 기여 | B 기여 | 누적 A | 누적 B |
+|:----:|------|:------:|:------:|:------:|:------:|
+| 기존 | Phase 0 + Phase 1a/1b 구현 | +10 | +4 | 71 | 70 |
+| Must 1 | IEC 62304 + 21 CFR + EU MDR baseline docs | +2 | +1 | 73 | 71 |
+| Must 2 | §524B + SBOM + Vuln Mgmt + Input Val | +2 | +1 | 75 | 72 |
+| Must 3 | PMS Plan + 보고 체계 | +0 | +1 | 75 | 73 |
+| Must 4 | DICOM Core + Conformance Statement 발행 | +0 | +1 | 75 | 74 |
+| Must 5 | Char. Test + Trackability (IEC 62304 §5.4.1) | +1 | +0 | 76 | 74 |
+
+**Milestone 1 (Must 12) 달성 조건 → 블로커 해소, 출시 가능 상태**:
+- IEC 62304 Class B 전체 서류
+- EU MDR + FDA §524B + 21 CFR 증빙
+- SBOM (SPDX 3.0 + CycloneDX 1.6) 발급
+- Vulnerability Management 프로세스 가동
+- PMS Plan 승인
+- DICOM Core + Conformance Statement
+- 모든 SWU Unit Test + RTM 매핑 완료
+
+### 3.2 Path 1-Ext: 76 → 85 (Must + 주요 Should)
+
+| 단계 | 행동 | A 기여 | B 기여 | 누적 A | 누적 B |
+|:----:|------|:------:|:------:|:------:|:------:|
+| Ext 1 | TRUST 5 전체 gate green | +2 | +1 | 78 | 75 |
+| Ext 2 | Reference + SIMD Parity 적용 | +1 | +2 | 79 | 77 |
+| Ext 3 | SLSA L2 달성 | +1 | +1 | 80 | 78 |
+| Ext 4 | Anti-Spaghetti + MX Tag 적용 | +1 | +1 | 81 | 79 |
+| Ext 5 | Reproducible Builds 증명 | +1 | +1 | 82 | 80 |
+| Ext 6 | IEC 81001-5-1 통합 | +1 | +1 | 83 | 81 |
+| Ext 7 | ISO 42001 AIMS 수립 | +1 | +1 | 84 | 82 |
+| Ext 8 | IHE RAD SWF.b/PDI/PIR 구현 | +1 | +2 | 85 | 84 |
+| Ext 9 | benchmark freeze + 재현 harness | 0 | +1 | 85 | 85 |
+
+**Milestone 1-Ext (85 목표) 달성 조건 → Must + Phase 연결 Should**:
+- Milestone 1 전체 완료
+- 품질/아키텍처 Should 4개 (TRUST 5, Parity, MX, Anti-Spaghetti)
+- 보안 Should 2개 (SLSA L2, IEC 81001-5-1)
+- 자발적 Should 1개 (ISO 42001 수립)
+- 상호운용 Should 1개 (IHE Baseline)
+- 운영 Should 1개 (Reproducible)
+
+### 3.3 Path 2: 85 → 95 (AI-Phase 3 + 전체 Should)
+
+| 단계 | 행동 | A 기여 | B 기여 | 누적 A | 누적 B |
+|:----:|------|:------:|:------:|:------:|:------:|
+| 6 | S-AI-01 SSL Denoising 배포 | +2 | +3 | 87 | 88 |
+| 7 | S-AI-04 Conformal UQ + S-AI-05 ONNX 1.20+ | +1 | +2 | 88 | 90 |
+| 8 | S-SEC-01 SLSA L3 달성 | +2 | +1 | 90 | 91 |
+| 9 | S-IOP-01 DICOMweb 배포 | +1 | +2 | 91 | 93 |
+| 10 | S-OPS-01 Drift Detection live | +2 | +1 | 93 | 94 |
+| 11 | Model Observer Quality Gate live | +1 | +1 | 94 | 95 |
+| 12 | S-IOP-03 IHE AIR/AIRA 시범 운영 | +1 | 0 | 95 | 95 |
+
+**목표 95 달성 조건**:
+- Should 19개 중 15개 이상 배포
+- Phase 3 AI 모듈 1개 이상 FDA 제출
+- Connectathon 1회 이상 참여
+- 판매 후 감시 지표 3개월 운영
+
+### 3.4 Path 3: 95 → 98+ (Could 선별 경로)
+
+- MedSAM 연구 프로토타입 (+1)
+- GPU production path (CUDA) (+1)
+- FHIRcast 파일럿 (+1)
+- Rust safety module 실험 (+1)
+
+---
+
+## 4. Prioritized Backlog (v3.0 - reconciled)
+
+### 4.1 즉시 (Q2 2026, 현재 스프린트)
+
+| 우선순위 | 항목 | SPEC | 예상 기여 (A/B/C) |
+|:--------:|------|------|:-------:|
+| P0 | SPEC-XPE-REG 초안 승인 | REG | +4 / +3 / +2 |
+| P0 | SBOM 자동화 (SPDX 3.0 + CycloneDX 1.6) | SEC | +2 / +2 / +1 |
+| P0 | Reproducible build CI | OPS | +1 / +2 / 0 |
+| P1 | S1-A xpe_preprocess 완료 | P1A | +5 / +5 / 0 |
+| P1 | Phase 1b 3개 DLL 시작 | P1B* | +3 / +3 / 0 |
+| P2 | Model Card API 스켈레톤 | REG + P3-AI | +1 / +1 / +1 |
+
+### 4.2 Q3-Q4 2026
+
+| 항목 | SPEC | 예상 기여 |
+|------|------|:--------:|
+| Phase 1b 완료 (enhance_basic, display, dicom) | P1B* | +5 / +5 / 0 |
+| S-SEC 전체 완료 | SEC | +3 / +2 / +3 |
+| S-OPS 기본 구현 (PMS, reject-analysis) | OPS | +2 / +3 / +1 |
+| S2-A, S2-B (advanced, gsvg) | P2-ADV, P2-GSVG | +4 / +6 / 0 |
+| DICOM Conformance Statement 발행 | IOP | +1 / +2 / 0 |
+
+### 4.3 2027
+
+| 항목 | SPEC | 예상 기여 |
+|------|------|:--------:|
+| S-IOP DICOMweb + FHIR R5 배포 | IOP | +2 / +3 / +5 |
+| Phase 3 AI (SSL denoising 먼저) | P3-AI | +3 / +6 / +10 |
+| EU AI Act 2027-08 deadline 대응 | REG | +5 / +2 / +5 |
+| SLSA L3 프로덕션 | SEC | +2 / +1 / +5 |
+| OpenTelemetry 프로덕션 배포 | OPS | +1 / +2 / +5 |
+
+---
+
+## 5. Gate Criteria for Each Milestone
+
+### 5.1 Gate to 76 (Must 12 완료, 블로커 해소, v3.1 NEW)
+
+- [ ] IEC 62304 Class B 전체 서류 (Char. Test, RTM 포함)
+- [ ] EU MDR 기본 준수 증명
+- [ ] FDA 21 CFR 820.30 + QMSR 2026 준비
+- [ ] FDA §524B + SBOM 발급
+- [ ] Vulnerability Management 프로세스 가동
+- [ ] Basic Input Validation 전체 C ABI 경계
+- [ ] DICOM Core + Conformance Statement 발행
+- [ ] PMS Plan 승인
+
+### 5.2 Gate to 85 (Must + 주요 Should, 재설정)
+
+- [ ] Milestone 1 (76) 전체 완료
+- [ ] 품질/아키텍처 Should 4개 (TRUST 5, Reference+SIMD Parity, MX Tag, Anti-Spaghetti)
+- [ ] Security Should: SLSA L2, IEC 81001-5-1 통합
+- [ ] Ops Should: Reproducible Builds 증명
+- [ ] Voluntary 자발: ISO 42001 수립 또는 roadmap
+- [ ] Interop Should: IHE SWF.b/PDI/PIR
+- [ ] FDA pre-submission (Q-Sub) 1회 이상 실행
+
+### 5.3 Gate to 95 (Must + 전체 Should, AI 포함)
+
+- [ ] 15개 이상 Should 배포 (19개 중)
+- [ ] Framework A ≥ 95
+- [ ] Framework B ≥ 93
+- [ ] Phase 3 AI 1개 이상 FDA 510(k) 또는 PMA 제출
+- [ ] IHE Connectathon 1회 참여
+- [ ] 판매 후 감시 3개월 운영 데이터
+- [ ] Model Observer Quality Gate 4개 모두 통과
+- [ ] SLSA L3 달성
+
+### 5.4 Gate to 98+ (Selective Could)
+
+- [ ] Phase 4 Research Track 3개 프로젝트 완료
+- [ ] Framework C ≥ 60
+- [ ] Foundation model 실험 1개 이상
+- [ ] GPU production path 1개 이상
+
+---
+
+## 6. Risk-Adjusted Scoring
+
+각 경로는 다음 리스크 시나리오로 스트레스 테스트:
+
+| 시나리오 | Framework A 영향 | 완화책 |
+|---------|:---------------:|-------|
+| FDA 가이던스 재발행 (PCCP 수정) | -3 | 모니터링 구독, 30일 내 대응 |
+| EU AI Act 이행법 변경 | -4 | EU Notified Body와 정기 소통 |
+| 주요 SOUP EOL (예: vcpkg 패키지) | -2 | 분기별 SOUP 건강 상태 체크 |
+| 경쟁사 AI 모듈 규제 실패 사례 | 0 | 학습 기회로 활용 |
+| Zero-day CVE on DCMTK | -3 | SLA 60일 패치 |
+| 파일럿 병원 drift 알림 폭발 | -2 | threshold 재보정 프로세스 |
+
+---
+
+## 7. 관측 가능한 진척도 지표 (KPI)
+
+주간·월간 트래킹:
+
+- **Framework A**: 문서 완성률, EARS 커버리지, RTM 매핑율
+- **Framework B**: SWU 구현률, 커버리지, 벤치마크 달성
+- **Framework C**: 실험 완료 수, Phase 4 백로그 진행
+- **Regulatory**: Must-REG 완료율, Q-Sub 피드백 반영
+- **Security**: CVE 노출률, SBOM 최신성, SLSA 레벨
+- **Interoperability**: Conformance 테스트 통과율
+- **Operations**: MTBF, drift 알림 정확도, reject 원인 분석
+
+---
+
+## 8. 승인 체크포인트
+
+- **v3.0.0 본 plan 승인**: 사용자 확인 필요
+- **85 달성 리뷰**: 분기별
+- **95 달성 리뷰**: 반기별
+- **98+ 진입 결정**: 연간
+
+---
+
+**본 plan은 v2.0.0을 대체하지 않고 extend한다. 85까지의 경로는 v2.0.0 유지, 85 이후 경로는 본 plan이 normative.**

--- a/.moai/specs/SPEC-XPE-MASTER/sprint-execution-roadmap-v3.md
+++ b/.moai/specs/SPEC-XPE-MASTER/sprint-execution-roadmap-v3.md
@@ -1,0 +1,337 @@
+# Sprint Execution Roadmap v3.0.0
+
+**Document ID**: SPRINT-ROADMAP-001
+**Version**: 3.0.0
+**Date**: 2026-04-17
+**Status**: Active (Supersedes v2.0.0)
+**Relationship**: Integrates `sprint-execution-roadmap-v2.md` + SPEC-XPE-MASTER v3.0.0 addendum + 4 new SPECs (REG/SEC/IOP/OPS) + P3-AI v1.0
+**Classification**: IEC 62304 Class B
+
+---
+
+## Changelog (v2.0.0 → v3.0.0 → v3.1 Strict)
+
+| Change | Detail |
+|--------|--------|
+| Sprint count | 11 → **14** sprints |
+| 3 cross-cutting sprints | S-REG, S-SEC, S-OPS (parallel tracks) added |
+| S3 updated | Now SPEC-XPE-P3-AI v1.1 (redefined with SSL+Diffusion+XAI+UQ) |
+| Dependency graph | Parallel tracks replace strict sequential flow for non-core sprints |
+| Coverage thresholds | Extended to governance SWUs (90%) |
+| Pre-sprint checklists | 4 new checklists for new sprints |
+| Quality gates | Added Model Observer + Regulatory + Security + Reproducibility gates |
+| **v3.1 Strict Must** | **S-REG/SEC/IOP/OPS 각각을 CORE(Must) + EXT(Should)로 분할. P0 Core만 즉시, Ext는 Phase 연결 조건부 진행.** |
+
+---
+
+## 1. Sprint Overview v3.0
+
+### 1.1 Full Sprint Matrix (14 sprints)
+
+| Sprint | SPEC | Phase | DLL/Module | SWU | API | EARS REQ | Priority | Track |
+|--------|------|:-----:|-----------|:---:|:---:|:--------:|:--------:|:-----:|
+| S0-A | SPEC-XPE-P0 | 0 | Build/CMake | -- | -- | 8 | Must | Core |
+| S0-B | SPEC-XPE-P0 | 0 | xpe_common | **11** (was 7, +4 new SWU) | 22 (was 18) | 28 | Must | Core |
+| S0-C | SPEC-XPE-P0 | 0 | ImageProcTest | 1 | N/A | 3 | Must | Core |
+| **S-REG-CORE** | **SPEC-XPE-REG (Must part)** | **parallel** | docs (IEC 62304/EU MDR/21 CFR) | gov | 2 | **~15** | **Must** | **Regulatory-Core** |
+| **S-REG-AI** | **SPEC-XPE-REG (Should part)** | **Phase 3 gating** | PCCP + Model Card + GMLP docs | gov | 2 | **~30** | Should (조건부 Must) | **Regulatory-AI** |
+| **S-SEC-CORE** | **SPEC-XPE-SEC (Must part)** | **parallel** | §524B + SBOM + Vuln Mgmt + Input Val | gov | 2 | **~20** | **Must** | **Security-Core** |
+| **S-SEC-EXT** | **SPEC-XPE-SEC (Should part)** | **parallel Phase 2** | SLSA L3 + IEC 81001-5-1 + Threat Model 확장 | gov | 1 | **~20** | Should | **Security-Ext** |
+| S1-A | SPEC-XPE-P1A | 1a | xpe_preprocess | 9 | 18 | ~45 | Must | Core |
+| S1-B1 | SPEC-XPE-P1B-ENH | 1b | xpe_enhance_basic | 5 | 7 | ~28 | Must | Core |
+| S1-B2 | SPEC-XPE-P1B-DISP | 1b | xpe_display | 4 | 11 | ~22 | Must | Core |
+| S1-B3 | SPEC-XPE-P1B-DICOM | 1b | xpe_dicom | 4 | 10 | ~22 | Must | Core |
+| S1-B4 | SPEC-XPE-P1B-GUI | 1b | ImageProcTest | 1+1 | N/A | ~12 | Should | Core |
+| **S-OPS-CORE** | **SPEC-XPE-OPS (Must part)** | **parallel** | PMS Plan + 보고 체계 | gov | 1 | **~8** | **Must** | **Ops-Core** |
+| **S-OPS-EXT** | **SPEC-XPE-OPS (Should part)** | **parallel Phase 2** | OTEL + Drift + Reproducible + VEX | gov (2) | 4 | **~22** | Should | **Ops-Ext** |
+| S2-A | SPEC-XPE-P2-ADV | 2 | xpe_enhance_advanced | 3 | 3 | ~18 | Must | Core |
+| S2-B | SPEC-XPE-P2-GSVG | 2 | gsvg | 4 | 8 | ~22 | Must | Core |
+| **S-IOP-CORE** | **SPEC-XPE-IOP (Must part)** | **1b 확장** | **xpe_dicom 강화 (Conformance Stmt)** | 0 | 0 | **~10** | **Must** | **Interop-Core** |
+| **S-IOP-EXT** | **SPEC-XPE-IOP (Should part)** | **2-3** | **xpe_interop** (new DICOMweb/FHIR/IHE) | **3** | **~14** | **~20** | Should | **Interop-Ext** |
+| S3 | **SPEC-XPE-P3-AI** | 3 | xpe_ai + worker | 4 | 15 (expanded) | **~40** (up from ~18) | Should (조건부 Must) | Core |
+
+**Totals v3.1**:
+- **Sprints (nominal)**: 14 sub-tracks (was 11 monolithic) — Must-only 진행 시 실제 P0 Sprint 수는 **9** (S0-A, S0-B, S0-C, S-REG-CORE, S-SEC-CORE, S1-A, S1-B1~B4, S-OPS-CORE, S-IOP-CORE)
+- **Must EARS REQ**: ~73 (IEC 62304 15 + §524B 20 + PMS 8 + DICOM 10 + Char.Test/Trackability 20)
+- **Should EARS REQ**: ~290 (조건부 진행)
+- **Total EARS REQ**: ~365 (variable by Phase decision)
+
+**실제 실행 단계**: Must 진행 (9 sprints) → 출시 가능 (M1 76점). 주요 Should 확장 (+ 추가 ~5 sub-tracks) → M1-Ext 85점 달성.
+
+### 1.2 Parallel Track Structure (v3.1 Strict)
+
+```
+Time →
+
+Track CORE:        S0-A ─┬─ S0-B ─┬─ S1-A ─┬─ S1-B1 ──┬─ S2-A ──┬─ (S3 조건부)
+                          └ S0-C   │        ├─ S1-B2   ├─ S2-B    
+                                   │        ├─ S1-B3 ──┼─ S-IOP-CORE (Must, DICOM Conformance)
+                                   │        └─ S1-B4   │
+Track REGULATORY-CORE: S-REG-CORE (Must: IEC 62304+EU MDR+21 CFR docs) ── 즉시 착수
+Track SECURITY-CORE:   ── S-SEC-CORE (Must: §524B+SBOM+Vuln Mgmt+Input Val) ── S0-B 후
+Track OPS-CORE:        ─────────────── S-OPS-CORE (Must: PMS Plan) ── S1-B1 후
+
+(Phase 2 extension - Should)
+Track REG-AI:          ──────── S-REG-AI (Should: PCCP/Transparency) ──── Phase 3 승인 시
+Track SEC-EXT:         ──────── S-SEC-EXT (Should: SLSA L3+IEC 81001-5-1) ── Phase 2
+Track OPS-EXT:         ──────── S-OPS-EXT (Should: OTEL/Drift/VEX) ─────── Phase 2
+Track IOP-EXT:         ──────── S-IOP-EXT (Should: DICOMweb/FHIR/IHE) ──── Phase 2-3
+
+Critical Path (Must-only, 출시 가능 상태): S0-A → S0-B → S1-A → S1-B1 → S1-B3 → [S-IOP-CORE]
+Parallel Must: S-REG-CORE, S-SEC-CORE, S-OPS-CORE (blocker 해소용 문서·프로세스)
+Phase 3 (조건부): S3 is Should tier; 시작하려면 Phase 3 AI-DSF 배포 공식 결정 필요
+```
+
+**v3.1 Key Change**: S3 (AI)는 Should. 즉, v2.0 목표 "S3 달성"이 출시 블로커가 아니며, Must-only 9 sprints 완료 시 법적으로 출시 가능 (Phase 1/2 결정적 전용 제품).
+
+### 1.3 Sprint Start Gating (v3.1 Strict)
+
+| Sprint | Priority | Start Gate |
+|--------|:--------:|-----------|
+| S0-A | Must | Project init |
+| S0-B | Must | S0-A complete |
+| S0-C | Must | S0-A complete |
+| **S-REG-CORE** | **Must** | **S0-A complete + legal counsel engaged (Must)** |
+| **S-SEC-CORE** | **Must** | **S0-B complete + security lead assigned (Must)** |
+| S1-A | Must | S0-B complete + api-spec v1.3 |
+| S1-B1-B4 | Must (B1-B3), Should (B4) | S1-A complete |
+| **S-OPS-CORE** | **Must** | **S1-B1 complete + PMS plan approved** |
+| **S-IOP-CORE** | **Must** | **S1-B3 complete (DICOM base) + Conformance Statement template** |
+| S2-A | Must | S1-B1 complete |
+| S2-B | Must | S1-A complete |
+| **S-SEC-EXT** | Should | S-SEC-CORE complete + SLSA L3 decision |
+| **S-OPS-EXT** | Should | S-OPS-CORE complete + OTEL endpoint decision |
+| **S-IOP-EXT** | Should | S-IOP-CORE complete + DICOMweb/FHIR business decision |
+| **S-REG-AI** | Should→Must | Phase 3 AI-DSF 배포 공식 결정 + FDA Q-Sub 계획 |
+| S3 | Should→Must | Phase 3 진입 결정 + S-REG-AI + S-SEC-EXT + S-OPS-EXT complete |
+
+---
+
+## 2. Quality Gates per Sprint (v3.0 Harmonized)
+
+### 2.1 Core Sprints
+
+| Gate | S0-A | S0-B | S0-C | S1-A | S1-B* | S2-A/B | S3 |
+|------|:----:|:----:|:----:|:----:|:-----:|:------:|:--:|
+| Unit Coverage | ≥85 | **≥90** | ≥70 | **≥90** | ≥85 | ≥85 | ≥80 |
+| Branch Coverage | ≥70 | **≥80** | ≥60 | **≥80** | ≥70 | ≥70 | ≥60 |
+| Static Analysis | 0 warn | 0 | 0 | 0 | 0 | 0 | 0 |
+| Memory Leak (1K frames) | Pass | Pass | Pass | Pass | Pass | Pass | Pass |
+| Performance Budget | N/A | <100ms | N/A | <500ms | <3000ms | <2500ms | <3000ms |
+| EARS Traceability | 8 | 28 | 3 | ~45 | ~84 | ~40 | ~40 |
+| P/Invoke ABI Test | Pass | Pass | Pass | Pass | Pass | Pass | Pass |
+| **NEW: Model Observer IQ** | -- | -- | -- | -- | -- | **Pass** | **Pass** |
+
+### 2.2 Cross-Cutting Sprints
+
+| Gate | S-REG | S-SEC | S-OPS | S-IOP |
+|------|:-----:|:-----:|:-----:|:-----:|
+| Document Coverage | 15 docs | 11 docs | 10 docs | 8 docs |
+| **Regulatory Sign-off** | **Legal + RA** | -- | -- | -- |
+| **Security Threat Model** | -- | **5 boundaries** | -- | -- |
+| **PMS Workflow** | -- | -- | **Tabletop** | -- |
+| **Conformance Test** | -- | -- | -- | **dcm4che+Orthanc+AWS HI** |
+| SBOM Quality | -- | **SPDX+CDX** | -- | -- |
+| SLSA Level | -- | **L2 minimum** | -- | -- |
+| Reproducibility | -- | -- | **Dual-build match** | -- |
+
+### 2.3 NEW Cross-Sprint Gates
+
+**Model Observer Quality Gate** (cross-ref MASTER v3 §E):
+- Enable for all SWUs producing diagnostic images: S1-B1, S1-B2, S2-A, S2-B, S3
+- AUC (Channelized Hotelling Observer) — AI output ≥ baseline - 0.02
+- Perceptual metrics (LPIPS, SSIM) reported alongside
+
+**Regulatory Gate** (applies to each release):
+- PCCP approved for each AI-DSF module
+- Model Card signed off
+- Data lineage audit complete
+
+**Security Gate** (applies to each release):
+- SBOM published (SPDX 3.0 + CycloneDX 1.6)
+- SLSA L2 minimum (L3 from v2.0)
+- Zero critical unresolved CVE
+- Threat model reviewed within 3 months
+
+**Reproducibility Gate** (applies to each release):
+- Build reproducibility verified (dual-build bit-identical)
+- Known exceptions documented
+
+---
+
+## 3. Pre-Sprint Checklists (Enhanced)
+
+### 3.1 v2.0 retained (S0-B, S1-A, S1-B* checklists)
+
+See `sprint-execution-roadmap-v2.md` §3.
+
+### 3.2 v3.0 NEW Checklists
+
+**Before S-REG**:
+- [ ] Legal counsel engaged
+- [ ] Regulatory Affairs lead assigned
+- [ ] FDA pre-submission (Q-Sub) booking prepared
+- [ ] Notified Body contact established (EU)
+- [ ] Clinical SME identified for Model Card review
+- [ ] Trend survey 2026 reviewed and approved
+
+**Before S-SEC**:
+- [ ] Security Lead assigned
+- [ ] Threat modeling training completed (STRIDE + EMB3D)
+- [ ] SLSA generator GitHub Actions template prepared
+- [ ] SBOM tooling chosen (syft + cyclonedx-cpp-maker)
+- [ ] SECURITY.md published
+- [ ] VDP contact verified
+
+**Before S-OPS**:
+- [ ] PMS Plan drafted and approved
+- [ ] OTEL Collector endpoint choice made (on-prem/cloud)
+- [ ] Drift detector architecture agreed (on-device/off-device)
+- [ ] Reject-analysis schema published
+- [ ] AAPM TG-151 methodology review completed
+
+**Before S-IOP**:
+- [ ] dcm4che test setup verified
+- [ ] Orthanc reference server configured
+- [ ] AWS HealthImaging demo account (for DICOMweb testing)
+- [ ] HAPI FHIR validator installed
+- [ ] IHE Connectathon 2026 calendar checked, registration planned
+
+**Before S3 (updated from v2.0)**:
+- [ ] All S-REG Must deliverables approved
+- [ ] SPEC-XPE-SEC §4.6 threat model for AI boundary complete
+- [ ] Training data governance approved + de-identification verified
+- [ ] ONNX Runtime 1.20+ environment validated on CPU/CUDA/TensorRT/DirectML
+- [ ] Signed model loading verified
+- [ ] Worker isolation process prototype validated
+- [ ] PCCP template for each AI-DSF approved
+- [ ] Reader study protocol drafted (for Should-tier AI validation)
+
+---
+
+## 4. Dependency Graph (v3.0)
+
+```
+                        ┌──── S-REG (docs + Layer 0 additions) ────────┐
+                        │                                               │
+                        │                                               ├──┐
+                        │                                               │  │
+S0-A ──┬─── S0-B ────┬──┘                                               │  │
+       │             │                                                  │  │
+       │             ├──── S-SEC (CI/CD + secure Layer 0) ──────────────┤  │
+       │             │                                                  │  │
+       │             └─── S1-A ──┬── S1-B1 ──┬── S-OPS (Layer 0 + CI)───┤  │
+       │                         │           │                          │  │
+       │                         ├── S1-B2   │                          │  │
+       └── S0-C                  ├── S1-B3 ──┼── S-IOP (Phase 2-3) ─────┤  │
+                                 └── S1-B4   │                          │  │
+                                             │                          │  │
+                                             ├── S2-A ──────────────────┤  │
+                                             │                          │  │
+                                             └── S2-B (parallel S2-A)   │  │
+                                                                        │  │
+                                                              ┌─ S3 ◀───┴──┘
+                                                              │
+                                                              ▼
+                                                        (Release Gate)
+```
+
+---
+
+## 5. Sprint Effort Estimates (Priority-Based, Not Time-Based)
+
+### 5.1 Effort Priority Matrix
+
+| Sprint | Effort | Risk | Priority | Can Start |
+|--------|:------:|:----:|:--------:|:---------:|
+| S0-A | Medium | Low | P0 | Immediately |
+| S0-B | High | Low | P0 | After S0-A |
+| S0-C | Low | Low | P0 | After S0-A |
+| S-REG | Medium-High | Medium (legal complexity) | P0 | After S0-A (in parallel) |
+| S-SEC | Medium | Low | P0 | After S0-B (in parallel) |
+| S1-A | High | Medium (9 SWUs) | P0 | After S0-B |
+| S1-B1 | Medium | Low | P0 | After S1-A |
+| S1-B2 | Low | Low | P0 | After S1-A |
+| S1-B3 | Medium | Medium (DICOM compat) | P0 | After S1-A |
+| S1-B4 | Low | Low | P1 | After S1-B1 |
+| S-OPS | Medium | Low | P1 | After S1-B1 |
+| S2-A | Medium-High | Medium (CLAHE + MFP) | P1 | After S1-B1 |
+| S2-B | High | High (GSVG IEC package) | P1 | After S1-A |
+| S-IOP | Medium | Medium (DICOMweb new) | P1 (Must baseline) | After S1-B3 |
+| S3 | High | High (AI + reg + sec) | P2 | After S2-A+S-REG+S-SEC+S-OPS |
+
+### 5.2 Phasing Recommendations
+
+**Wave 1** (Parallel, Immediate): S0-A, S-REG (docs)
+**Wave 2** (After S0-A): S0-B, S0-C, S-REG continues
+**Wave 3** (After S0-B): S-SEC starts, S1-A starts
+**Wave 4** (After S1-A): S1-B1, S1-B2, S1-B3 parallel; S-REG/SEC continue
+**Wave 5** (After S1-B1): S-OPS, S1-B4, S2-A
+**Wave 6** (After S2-A): S-IOP, S2-B
+**Wave 7** (After all above + REG/SEC/OPS complete): S3
+
+---
+
+## 6. Release Cadence
+
+### 6.1 Minor Release (v0.x) — per wave
+
+- v0.1: S0-* complete → Phase 0 baseline
+- v0.2: S1-A complete → Preprocess available
+- v0.3: S1-B* complete → Full Phase 1 (diagnostic-capable deterministic)
+- v0.4: S2-* complete → Phase 2 premium deterministic
+- v0.5: S-REG + S-SEC + S-OPS artifacts complete → regulatory-ready
+- v0.6: S-IOP complete → interoperable
+
+### 6.2 Major Release (v1.x)
+
+- **v1.0**: All Must items complete (target score A=85, B=85)
+  - Requires: S0, S1, S2 + S-REG + S-SEC + S-OPS + S-IOP (baseline)
+  - Regulatory: first FDA submission
+  
+- **v2.0**: Must + Should items (target score A=95, B=95)
+  - Adds: S3 Phase 3 AI + S-IOP extended (DICOMweb + IHE AIR/AIRA)
+  - Regulatory: AI-DSF modules submitted
+
+- **v3.0** (2027+): Must + Should + selected Could (target A=98, B=98, C=60)
+
+---
+
+## 7. Regulatory Calendar (Informational)
+
+| Date | Event | Action |
+|------|-------|--------|
+| 2025-04-07 | FDA Lifecycle Draft 의견 종료 | Final 발행 대기 |
+| 2025-06-16 | UK MHRA PMS Regs 발효 | S-OPS PMS 설계 영향 |
+| 2025-06-27 | FDA Cybersecurity Final | S-SEC 정합성 확인 |
+| 2026-02-02 | US QMSR 발효 | S-REG QMSR gap analysis 완료 |
+| 2026-05-28 | EU EUDAMED 전면 가동 시작 + 6개월 전환 | Q2 2026 준비 |
+| 2027-08-01 | **EU AI Act 의료기기 AI 전면 의무** | **S-REG 완료 필수** |
+
+---
+
+## 8. Resources/Roles Needed
+
+| Role | Responsibility | Sprint |
+|------|---------------|--------|
+| Technical Lead | 아키텍처, 전체 조정 | 전체 |
+| Regulatory Affairs Lead | FDA/EU submissions | S-REG, S3 |
+| Security Lead | §524B, threat modeling | S-SEC |
+| Clinical SME | Model card review, reader study | S-REG, S3 |
+| Legal Counsel | 규제 해석 | S-REG |
+| DevOps/SRE | CI/CD, SLSA | S0-A, S-SEC, S-OPS |
+| Data Governance | Lineage, bias | S-REG, S3 |
+| ML Engineer | AI training, benchmarks | S3 |
+| DICOM/FHIR Engineer | Interop implementation | S1-B3, S-IOP |
+
+---
+
+## 9. Change Control
+
+- v3.0.0 approval: User 확인 필요
+- v3.x minor: 기존 sprint scope 내 세부 변경
+- v4.0.0: Phase 4 Research Track 편입
+
+---
+
+**본 roadmap은 v2.0.0을 대체한다. v2.0.0의 기존 11 sprints는 그대로 유지되며, 3개의 cross-cutting parallel sprints가 추가되어 14 sprints로 확장된다.**

--- a/.moai/specs/SPEC-XPE-MASTER/v3-upgrade.md
+++ b/.moai/specs/SPEC-XPE-MASTER/v3-upgrade.md
@@ -1,0 +1,350 @@
+# SPEC-XPE-MASTER v3.0.0 Upgrade Addendum
+
+**Document ID**: SPEC-XPE-MASTER (v3 addendum)
+**Version**: 3.0.0
+**Date**: 2026-04-17
+**Status**: Draft — Upgrades v2.0.0
+**Author**: MoAI (manager-spec orchestration, integrating trend-survey-2026.md)
+**Classification**: IEC 62304 Class B
+**Relationship**: This addendum EXTENDS SPEC-XPE-MASTER/spec.md (v2.0.0); the two documents must be read together. v3.0.0 does not supersede v2.0.0 except where explicitly marked.
+
+---
+
+## A. Changelog (v2.0.0 → v3.0.0)
+
+| Area | v2.0.0 | v3.0.0 | Rationale |
+|------|--------|--------|-----------|
+| SPEC count | 4 (MASTER, P0, P1A, P2-ADV) | **9** (+ REG, SEC, IOP, OPS, P3-AI) | 2024-2026 규제·보안·상호운용성 축 통합 |
+| Must/Should/Could matrix | implicit | **explicit 55 items** | 사용자 요구 "기본 필수는 반드시 Must" 반영 |
+| Total SWU | 43 | **48 (+5 governance SWU)** | xpe_interop (3), AI governance (2) 신설 |
+| Total APIs | 82 | **~105** | DICOMweb (8), FHIR (6), OTEL (5), XAI (4) 등 |
+| Total EARS REQ | ~223 | **~330** | REG 40 + SEC 35 + IOP 30 + OPS 30 = 135 추가 |
+| Sprints | 11 | **14** | S-REG, S-SEC, S-IOP, S-OPS 추가 (S3 변경) |
+| Quality Gates | TRUST 5 + LSP | **+ Model Observer TG-270** | Task-based image quality 도입 |
+| 규제 커버리지 | IEC 62304 Class B만 | **+ FDA PCCP/AI-DSF + EU AI Act + ISO 42001 + QMSR** | 시장 출시 필수 |
+
+---
+
+## B. Must / Should / Could Matrix Integration (v1.1 Strict)
+
+전체 57 항목은 `.moai/project/trend-survey-2026.md` v1.1에 상세 정의됨. 본 MASTER에는 **요약 매트릭스**와 **SWU/REQ 매핑**만 기록.
+
+**v1.1 Strict Reclassification** (2026-04-17 재평가): Must 27 → **12**, Should 19 → **35**, Could 10. Must는 "법률 의무 + 시장 진입 블로커 + IEC 62304 강제 조항"으로 엄격 한정.
+
+### B.1 Must Tier Summary (12 items, v1.1)
+
+| Axis | Count | IDs | Normative SPEC |
+|------|:-----:|-----|----------------|
+| Regulatory | 3 | M-01 (IEC 62304), M-02 (EU MDR), M-03 (21 CFR/QMSR) | SPEC-XPE-REG (core 부분) |
+| Cybersecurity | 4 | M-04 (§524B), M-05 (SBOM), M-06 (Vuln Mgmt), M-07 (Input Val) | SPEC-XPE-SEC (core 부분) |
+| Interoperability | 2 | M-08 (DICOM 3.0), M-09 (Conformance Stmt) | SPEC-XPE-IOP (core 부분) |
+| Operations | 1 | M-10 (PMS) | SPEC-XPE-OPS (core 부분) |
+| Quality/Arch | 2 | M-11 (Char. Test IEC §5.4.1), M-12 (Trackability IEC §5.4.1) | 기존 P1A/P1B/P2-ADV |
+
+**판정 기준 (엄격)**: 법률(Law) OR 시장 진입 거절 사유 OR IEC 62304 강제 조항
+
+### B.2 Should Tier Summary (35 items, v1.1)
+
+v1.0 Must → Should 강등 (15): PCCP, AI-DSF Lifecycle Draft, Transparency, GMLP, EU AI Act, ISO 42001, IEC 81001-5-1, IHE RAD Baseline, TRUST 5, Reference+SIMD Parity, MX Tag, Anti-Spaghetti, Reproducible Builds, Model Card, Data Lineage, Deterministic Fallback
+
+v1.0 Should 유지 (19): SLSA L3, DICOMweb, FHIR R5, IHE AIR/AIRA, SSL Denoising, Diffusion Priors, Conformal UQ, XAI, ONNX 1.20+, Drift Detection, OpenTelemetry, VEX Auto, Reject-Analysis 등
+
+Representative:
+- S-REG-03~08: AI 관련 규제 (AI-DSF 배포 조건부)
+- S-SEC-01 (SLSA L3), S-SEC-05 (IEC 81001-5-1)
+- S-IOP-01~03 (DICOMweb/FHIR R5/IHE AIR/AIRA)
+- S-AI-01~08 (SSL+Diffusion+XAI+UQ+Governance)
+- S-OPS-01~05 (Drift+OTEL+VEX+Reject+Reproducible)
+
+### B.3 Could Tier Summary (10 items, 유지)
+
+모두 Phase 4 Research Track 또는 Post-Market Evolution으로 격리.
+
+### B.4 Conditional Upgrade Rules (v1.1 신규)
+
+다음 조건 충족 시 Should → Must 승격:
+- **S-REG-03 FDA PCCP**: Phase 3 AI-DSF 배포 승인 → Must
+- **S-REG-07 EU AI Act**: EU 시장 + AI 탑재 판매 → Must
+- **S-AI-06/07/08 (Model Card/Lineage/Fallback)**: Phase 3 AI 개발 시작 → Must
+- **S-IOP-05 IHE Baseline**: Connectathon 참여 결정 → Must
+
+조건부 승격 체크포인트: 각 Phase 진입 전 Gate Review에서 재평가.
+
+---
+
+## C. Updated Architecture Diagram (Layer View)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Layer 2: ImageProcTest.exe (C# WPF)                                │
+│  - SWU-5.7 PipelineOrchestrator                                      │
+│  - SWU-6.1 QaConstancyTest                                           │
+│  - NEW: SWU-6.2 AiInfoDisplay (Model Card UI, XAI sidecar viewer)    │
+└────────────────────────────────┬────────────────────────────────────┘
+                                 │ P/Invoke
+         ┌───────────────────────┼───────────────────────┐
+         │                       │                       │
+┌────────▼─────────┐   ┌─────────▼────────┐   ┌──────────▼──────────┐
+│ Layer 1: XPE DLLs │   │ Layer 1-G: GSVG  │   │ NEW: xpe_interop    │
+│ (preprocess, basic,│   │ (independent)    │   │ - DICOMweb client   │
+│  advanced, display,│   │                  │   │ - FHIR R5 adapter   │
+│  dicom, ai)        │   │                  │   │ - IHE AIR encoder   │
+└────────┬─────────┘   └──────────────────┘   └──────────┬──────────┘
+         │                                                │
+         └────────────────┬───────────────────────────────┘
+                          │
+┌─────────────────────────▼─────────────────────────────────────────┐
+│ Layer 0: xpe_common.dll                                            │
+│ - Types, Memory, Config, Logger, Alert, AED (v2.0)                 │
+│ - NEW: xpe_otel (OpenTelemetry wrapper)                            │
+│ - NEW: xpe_telemetry (drift/reject/DI events)                      │
+│ - NEW: xpe_model_card (AI governance)                              │
+│ - NEW: xpe_secure (crypto helpers, signature verify)               │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## D. Updated SWU Inventory Summary (48 units)
+
+### D.1 Delta from v2.0.0 (43 → 48)
+
+**New SWUs (5)**:
+
+| ID | Name | DLL | Phase | SPEC |
+|----|------|-----|:-----:|------|
+| SWU-0.8 | OtelInstrumentation | xpe_common | 0 | OPS |
+| SWU-0.9 | TelemetryEventBus | xpe_common | 0 | OPS |
+| SWU-0.10 | ModelCardAPI | xpe_common | 0 | REG |
+| SWU-0.11 | SecurePrimitives | xpe_common | 0 | SEC |
+| SWU-interop.1 | DicomwebClient | xpe_interop | 2 | IOP |
+| SWU-interop.2 | FhirR5Adapter | xpe_interop | 2 | IOP |
+| SWU-interop.3 | IheAiResultsEncoder | xpe_interop | 3 | IOP |
+
+**Note**: SWU-interop.1 and SWU-interop.2 count as Phase 2 additions (bringing Phase 2 SWU from 8 to 10).
+
+### D.2 Coverage Thresholds (Harmonized v3.0)
+
+| Category | Coverage Target | Rationale |
+|----------|:---------------:|-----------|
+| Layer 0 core | 90% | Foundational safety |
+| Preprocess (Phase 1a) | 90% | Clinical safety-critical |
+| Basic enhance/display/dicom (Phase 1b) | 85% | Diagnostic path |
+| Advanced (Phase 2) | 85% | Differentiator |
+| AI (Phase 3) | 80% | Complex ML; supplemental test |
+| Interop (Phase 2-3) | 85% | Standard compliance |
+| Governance (Layer 0) | 90% | Audit critical |
+
+---
+
+## E. Quality Gates v3.0
+
+### E.1 Retained from v2.0
+
+- TRUST 5 (Tested, Readable, Unified, Secured, Trackable)
+- LSP gates (zero errors, bounded warnings)
+- Coverage thresholds (per category)
+- Branch coverage
+- Static analysis
+- Memory leak detection
+- Performance budgets
+
+### E.2 NEW in v3.0
+
+**Model Observer Quality Gate (AAPM TG-270 Family Integration)**
+
+For AI and enhancement tiers that produce diagnostic images, introduce task-based image quality gates:
+
+- **Gate M-IQ-01**: For each AI-enhanced output, compute mathematical model observer metrics (e.g., Channelized Hotelling Observer for detection tasks) against baseline deterministic path
+- **Gate M-IQ-02**: AI output shall not decrease model observer AUC by more than 0.02 compared to deterministic reference
+- **Gate M-IQ-03**: Perceptual metrics (LPIPS, SSIM) shall be reported alongside MSE/PSNR
+- **Gate M-IQ-04**: For diagnostic-relevant AI outputs, radiologist reader study result shall be appended to acceptance package before Phase 3 release
+
+**Regulatory Gate**
+
+- **Gate M-REG-G-01**: Each AI-DSF shall have an approved PCCP document before Phase 3 release
+- **Gate M-REG-G-02**: Each AI-DSF shall have a signed-off Model Card before release
+- **Gate M-REG-G-03**: Data lineage audit trail verified complete
+
+**Security Gate**
+
+- **Gate M-SEC-G-01**: SBOM published in both SPDX 3.0 and CycloneDX 1.6 formats
+- **Gate M-SEC-G-02**: SLSA L2 attestation present (L3 by Phase 2)
+- **Gate M-SEC-G-03**: Zero critical unresolved CVE (or VEX-justified)
+- **Gate M-SEC-G-04**: Threat model review within 3 months of release
+
+**Reproducibility Gate**
+
+- **Gate M-OPS-G-01**: Release build reproducibility verified (bit-identical from identical source+env)
+
+---
+
+## F. Updated Sprint Structure (14 Sprints)
+
+### F.1 Sprint Matrix v3.0
+
+| Sprint | SPEC | Phase | DLL/Module | Priority | Dependency |
+|--------|------|:-----:|-----------|:--------:|-----------|
+| S0-A | SPEC-XPE-P0 | 0 | Build/CMake | Must | None |
+| S0-B | SPEC-XPE-P0 | 0 | xpe_common | Must | S0-A |
+| S0-C | SPEC-XPE-P0 | 0 | ImageProcTest | Must | S0-A |
+| S1-A | SPEC-XPE-P1A | 1a | xpe_preprocess | Must | S0-B |
+| S1-B1 | SPEC-XPE-P1B-ENH | 1b | xpe_enhance_basic | Must | S1-A |
+| S1-B2 | SPEC-XPE-P1B-DISP | 1b | xpe_display | Must | S1-A |
+| S1-B3 | SPEC-XPE-P1B-DICOM | 1b | xpe_dicom | Must | S1-A |
+| S1-B4 | SPEC-XPE-P1B-GUI | 1b | ImageProcTest | Should | S1-B1 |
+| **S-REG** | **SPEC-XPE-REG** | **parallel** | (docs + Layer 0 additions) | **Must** | **S0-A (can start early)** |
+| **S-SEC** | **SPEC-XPE-SEC** | **parallel** | (CI/CD + Layer 0) | **Must** | **S0-B** |
+| S2-A | SPEC-XPE-P2-ADV | 2 | xpe_enhance_advanced | Must | S1-B1 |
+| S2-B | SPEC-XPE-P2-GSVG | 2 | gsvg | Must | S1-A |
+| **S-IOP** | **SPEC-XPE-IOP** | **2** | **xpe_interop (new)** | **Must (baseline) + Should (ext)** | **S1-B3, S2-A** |
+| **S-OPS** | **SPEC-XPE-OPS** | **parallel** | (xpe_common + CI + docs) | **Must** | **S1-B1** |
+| S3 | **SPEC-XPE-P3-AI** | 3 | xpe_ai + worker | Should | S2-A, S1-B4, S-REG complete |
+
+**Total**: 14 sprints (was 11), **3 cross-cutting parallel sprints** (S-REG, S-SEC, S-OPS) can run concurrently with core build sprints after their dependency is satisfied.
+
+### F.2 Updated Critical Path
+
+```
+                                    ┌─────────────────────────────────┐
+                                    │ S-REG (regulatory docs, parallel)│
+                                    └─────────────────────────────────┘
+                                    ┌─────────────────────────────────┐
+                                    │ S-SEC (security infra, parallel) │
+                                    └─────────────────────────────────┘
+                                                  │
+S0-A ──┬── S0-B ──┬── S1-A ──┬── S1-B1 ──┬── S2-A ──┬── S3 (Must REG complete)
+       │           │           │           │         │
+       └── S0-C    │           ├── S1-B2   │         │
+                   │           ├── S1-B3 ──┼── S-IOP (ext) ─┘
+                   │           └── S1-B4   │
+                   └────────── S-OPS ──────┘
+                                           │
+                                           └── S2-B (parallel with S2-A)
+```
+
+**Critical Path (Must)**: S0-A → S0-B → S1-A → S1-B1 → S2-A → S3  
+**Parallel Must Tracks**: S-REG (start after S0-A), S-SEC (after S0-B), S-OPS (after S1-B1)
+
+### F.3 Pre-Sprint Checklist Additions
+
+**Before S-REG**:
+- [ ] Legal counsel engaged
+- [ ] Regulatory Affairs lead assigned
+- [ ] FDA pre-submission (Q-Sub) booking prepared
+- [ ] Notified Body contact established (EU)
+
+**Before S-SEC**:
+- [ ] Security Lead assigned
+- [ ] Threat modeling training completed
+- [ ] SLSA generator GitHub Actions workflow template prepared
+
+**Before S-OPS**:
+- [ ] PMS data flow design approved
+- [ ] OTEL Collector endpoint configured
+
+**Before S-IOP**:
+- [ ] dcm4che test setup verified
+- [ ] Orthanc reference server configured
+- [ ] IHE Connectathon calendar checked
+
+**Before S3 (updated)**:
+- [ ] All S-REG deliverables approved (PCCP, Model Cards templates)
+- [ ] SPEC-XPE-SEC §4.6 Threat Model completed for AI boundary
+- [ ] Training data governance approved
+- [ ] ONNX Runtime 1.20+ environment validated
+
+---
+
+## G. Pipeline Update (v3.0)
+
+```
+Raw Frame
+ -> (0)   CalibManager Load
+ -> (0.5) PRE-01 Readout Artifact Validation (Phase 1a)
+ -> (0.7) PRE-07 Temperature Compensation (Phase 1a)
+ -> (1)   PRE-02 Offset Correction (Phase 1a)
+ -> (1.5) PRE-08 Nonlinearity Correction (Phase 1a)
+ -> (2)   PRE-03 Gain Correction (Phase 1a)
+ -> (2.5) PRE-09 Binning Correction (Phase 1a, conditional)
+ -> (3)   PRE-06 basic Defect Correction (Phase 1a)
+      [AI-tier: PRE-06 ML ViT AE (Phase 3, opt-in, worker-isolated)]
+ -> (4)   PRE-04/05 Ghost/Lag Correction (Phase 1a)
+ -> (EI-0) Whole-image EI baseline (Phase 1b)
+ -> (5)   POST-01 Log Transform (Phase 1b)
+ -> (5a)  POST-06 Body Part Recognition (Phase 3)
+ -> (5b)  POST-07 baseline Collimation (Phase 2)
+      [AI-tier: POST-07 AI Collimation (Phase 3, opt-in)]
+ -> (EI-1) ROI-aware EI refinement (Phase 2)
+ -> (6)   POST-02 Noise Reduction (Phase 1b)
+      [AI-tier: POST-02 SSL Denoising (Phase 3)]
+      [premium: POST-02 Diffusion Priors (Phase 3, opt-in)]
+ -> (7)   POST-03 Contrast Enhancement (Phase 1b)
+ -> (8)   POST-04 Edge Enhancement (Phase 1b)
+ -> (9)   GSVG POST-10/11 (Phase 2, independent DLL)
+ -> (10)  POST-05 Multiscale Processing (Phase 2)
+ -> (11)  Fractional Processing (Phase 2)
+ -> (12)  POST-08 Image Stitching (Phase 3, conditional)
+ -> (13)  POST-09 Bone Suppression (Phase 3, optional)
+ -> (14)  POST-12a Modality LUT (Phase 1b)
+ -> (15)  POST-12b VOI LUT (Phase 1b)
+ -> (16)  POST-12c Presentation LUT (Phase 1b)
+ -> (17)  SUP-04 DICOM Write (Phase 1b)
+ *** NEW parallel sidecars (emitted at each AI-tier) ***
+ -> Sidecar Emitter: model_id, confidence, saliency_ref, uq_set, drift_fingerprint
+ -> OTEL Span Boundary: each stage wraps span if opt-in enabled
+ -> Telemetry Events: DI, reject-flag, drift alerts
+ *** NEW parallel export (optional) ***
+ -> DICOMweb STOW-RS to remote PACS (SPEC-XPE-IOP)
+ -> FHIR ImagingStudy/ImagingSelection to EHR
+ -> IHE AIR SR to reporting system
+```
+
+---
+
+## H. Document Update Matrix v3.0
+
+| Document | v2.0.0 | v3.0.0 Target | Priority |
+|----------|:------:|:-------------:|:--------:|
+| SPEC-XPE-MASTER | v2.0.0 | **v3.0.0 (본 addendum)** | Done |
+| trend-survey-2026 | — | **v1.0.0** | Done |
+| SPEC-XPE-REG | — | **v1.0.0** | Done |
+| SPEC-XPE-SEC | — | **v1.0.0** | Done |
+| SPEC-XPE-IOP | — | **v1.0.0** | Done |
+| SPEC-XPE-OPS | — | **v1.0.0** | Done |
+| SPEC-XPE-P3-AI | — | **v1.0.0** | Done |
+| score-improvement-plan | v2.0.0 | **v3.0.0** | Done (companion) |
+| sprint-execution-roadmap | v2.0.0 | **v3.0.0** | Pending |
+| product.md | v1.0 | **v2.0** | Pending |
+| tech.md | v1.0 | **v2.0** | Pending |
+| api-spec.md | v1.2 (planned) | **v1.3** | Pending |
+| XPE-SDD-001 | v1.0 | **v1.2** | Pending |
+| XPE-SRS-001 | v1.0 | **v1.2** | Pending |
+| XPE-RTM-001 | v1.0 | **v1.2** | Pending |
+| pipeline-spec | v1.1 | **v1.2** | Pending |
+
+---
+
+## I. Risk Addendum (v3.0 Global)
+
+| ID | Risk | Severity | Mitigation |
+|----|------|:--------:|-----------|
+| R-M3-01 | 병행 3개 sprint (REG/SEC/OPS) 자원 경쟁 | Medium | Role matrix: Regulatory, Security, DevOps leads 각각 할당 |
+| R-M3-02 | EU AI Act 2027 deadline pressure | High | S-REG 즉시 착수; pre-submission consultation Q1-2027 |
+| R-M3-03 | AI governance가 Phase 1a 지연 야기 | Medium | 문서 작업은 S-REG parallel track, 구현은 Phase 3 전 완료 |
+| R-M3-04 | Model Observer Quality Gate 측정 인프라 부재 | Medium | Phase 2에 IQ measurement pipeline 구축 |
+| R-M3-05 | SPDX/CycloneDX 동시 지원 복잡도 | Low | `syft` + `cyclonedx-cpp-maker` 툴체인 표준화 |
+| R-M3-06 | DICOMweb 성능이 기존 DIMSE보다 느림 | Medium | 옵션 제공, 사이트별 선택; 성능 벤치마크 harness |
+| R-M3-07 | IHE AIRA 신규 프로필 (2025-06) 미검증 | Medium | Connectathon 2026 early adoption plan |
+
+---
+
+## J. Versioning Governance
+
+- **v3.0.0**: 본 addendum 승인 시 (사용자 승인 필요)
+- **v3.x (minor)**: 신규 SPEC 추가 또는 기존 SPEC 개정
+- **v4.0.0**: Phase 4 Research Track (Could 티어) 전환 시점
+
+---
+
+**본 Addendum은 v2.0.0 마스터 문서와 병행하여 읽어야 하며, 2024-2026 규제·보안·상호운용성·AI 트렌드를 통합한 최종 상위 설계이다.**

--- a/.moai/specs/SPEC-XPE-OPS/spec.md
+++ b/.moai/specs/SPEC-XPE-OPS/spec.md
@@ -1,0 +1,321 @@
+# SPEC-XPE-OPS: Operations, Observability & Post-Market Surveillance Master
+
+---
+id: SPEC-XPE-OPS
+version: 1.1.0
+status: Draft
+created: 2026-04-17
+updated: 2026-04-17
+author: MoAI (manager-spec orchestration)
+priority: Mixed (Must for M-10 PMS; Should for Drift/OTEL/Reproducible/VEX)
+issue_number: null
+iec62304_class: B
+development_mode: TDD
+sprint: S-OPS-CORE (Must) + S-OPS-EXT (Should)
+dependency: SPEC-XPE-MASTER v3.0.0, SPEC-XPE-REG v1.1, trend-survey-2026.md v1.1
+---
+
+## Priority Reclassification Notice (v1.1)
+
+본 SPEC의 우선순위는 trend-survey-2026.md v1.1 엄격 재분류에 따라 혼합:
+
+- **Must (즉시, EU MDR 법적 의무)**: Post-Market Surveillance (PMS) Plan + 심각 사고 보고 체계 (M-10)
+- **Should (강력 권장, 조건부)**: Reproducible Builds, Data/Concept Drift Detection, OpenTelemetry Instrumentation, Reject-Analysis, VEX Automation
+- **강등 근거**: PMS는 EU MDR Art 83 법률 → Must. 나머지는 현대적 관측성·운영 우수성이나 법적 의무 아님
+- **현재 실행 범위**: PMS 기본 체계만 즉시, 나머지는 Phase 2-3 확장
+
+## HISTORY
+
+| Version | Date       | Author       | Changes                                   |
+|---------|------------|--------------|-------------------------------------------|
+| 1.0.0   | 2026-04-17 | MoAI         | Initial EARS SPEC integrating Post-Market Surveillance + Reproducible Builds + Data/Concept Drift Detection + OpenTelemetry + Reject-Analysis + VEX automation |
+
+---
+
+## 1. Scope
+
+### 1.1 Overview
+
+본 SPEC은 XPE의 **운영·관측성·판매 후 감시 마스터 문서**로서, 의료기기 제조업체의 법적 PMS 의무(EU MDR Article 83, MHRA PMS Regs 2025-06-16 발효)와 FDA AI 판매 후 모니터링 가이던스를 통합한다.
+
+본 SPEC이 다루는 5개 축:
+
+1. **Post-Market Surveillance (PMS)** — Must, 법적 의무
+2. **Reproducible Builds** — Must, SBOM/SLSA 기본 전제
+3. **Data/Concept Drift Detection** — Should, AI 지속 모니터링
+4. **OpenTelemetry Instrumentation** — Should, 현대적 관측성
+5. **Reject-Analysis + VEX Automation** — Should + Must 혼합
+
+### 1.2 In Scope
+
+- PMS 계획서 및 보고 체계 (MDR Annex III, FDA §522 연계)
+- Reject-analysis (재촬영 이벤트) 수집·분석
+- Deviation Index (DI) drift telemetry (기존 score-plan §6)
+- AI 모듈 data drift / concept drift 검출기
+- OpenTelemetry Traces/Metrics/Logs/Profiles API 통합 (opt-in)
+- Reproducible build 보증 메커니즘
+- VEX 자동 생성 및 공개 파이프라인
+- Customer feedback → issue tracking 연계
+
+### 1.3 Exclusions
+
+- Regulatory governance → SPEC-XPE-REG
+- Cybersecurity incident response → SPEC-XPE-SEC §4.9
+- AI model implementation → SPEC-XPE-P3-AI
+- Hospital-side PACS operations → out of scope
+- Personal data analytics infrastructure → hospital responsibility
+
+---
+
+## 2. Referenced Documents
+
+| Document ID | Title | Version | Role |
+|-------------|-------|---------|------|
+| EU-MDR-Art83 | Article 83: Post-market surveillance system | 2017/745 | Normative |
+| EU-MDR-Annex-III | Post-market surveillance plan | 2017/745 | Normative |
+| MHRA-PMS-2025 | UK PMS Regs | 2025-06-16 발효 | Normative (UK market) |
+| FDA-PMS-RFI | Methods and Tools for Effective Postmarket Monitoring of AI-Enabled MD | 2024 RFI | Informative |
+| NAT-DIG-MED-2024 | Distribution shift detection for postmarket surveillance | Nature Digital Med 2024 | Informative |
+| NAT-COMM-2024 | Empirical data drift detection experiments | Nature Communications 2024 | Informative |
+| OTEL-SPEC | OpenTelemetry Specification | 1.x (2025) | Normative (choice) |
+| CDX-VEX | CycloneDX VEX | 1.6 | Normative (choice) |
+| CSAF-2.0 | Common Security Advisory Framework | 2.0 | Normative (choice) |
+| REPRO-BUILDS | Reproducible Builds project | ongoing | Informative |
+| AAPM-TG-151 | Ongoing QC in Digital Radiography | 2015 | Informative |
+| SPEC-XPE-MASTER | XPE Master | v3.0.0 | Upstream |
+| SPEC-XPE-REG | Regulatory Master | v1.0 | Upstream |
+| SPEC-XPE-SEC | Cybersecurity Master | v1.0 | Upstream |
+
+---
+
+## 3. Definitions
+
+| Term | Definition |
+|------|-----------|
+| PMS | Post-Market Surveillance |
+| PSUR | Periodic Safety Update Report (MDR) |
+| PSR | Periodic Summary Report (MDR Class IIa/IIb/III) |
+| Data Drift | Input distribution shift post-deployment |
+| Concept Drift | Relationship between input and output changes |
+| Model Drift | Performance degradation (aggregate) |
+| DI | Deviation Index (IEC 62494-1, exposure index) |
+| Reject-Analysis | Statistical analysis of re-acquisition events |
+| OTEL | OpenTelemetry |
+| VEX | Vulnerability Exploitability eXchange |
+| PURL | Package URL |
+| Reproducible Build | Bit-identical output from identical inputs |
+| SOURCE_DATE_EPOCH | Environment variable for deterministic timestamps |
+| FHIR AuditEvent | FHIR resource for audit logging |
+| OSCAL | Open Security Controls Assessment Language |
+
+---
+
+## 4. Requirements (EARS Format)
+
+### 4.1 Post-Market Surveillance (Must)
+
+**REQ-OPS-001** (Ubiquitous): The XPE manufacturer shall maintain a Post-Market Surveillance Plan per MDR Annex III, including: product scope, data sources, indicators, review frequency, responsibility matrix.
+
+**REQ-OPS-002** (Ubiquitous): The XPE system shall emit audit events for: installation, configuration change, each processed study, AI model inference, error conditions, user override.
+
+**REQ-OPS-003** (Ubiquitous): Audit events SHOULD be recorded in OpenTelemetry format and SHALL also be recordable in FHIR AuditEvent resource when enabled.
+
+**REQ-OPS-004** (Event-driven): When a serious incident is detected or reported, the manufacturer shall initiate notification to competent authorities within MDR-specified timelines (serious: 2 days; fatality or deterioration: 10 days).
+
+**REQ-OPS-005** (Ubiquitous): The manufacturer SHALL publish Periodic Safety Update Reports (PSUR) at frequencies: Class IIb/III annually, Class IIa biannually (per MDR Article 86).
+
+**REQ-OPS-006** (Ubiquitous): MHRA PMS regulations (UK) shorter timelines SHALL be observed for UK deployments.
+
+### 4.2 Reproducible Builds (Must)
+
+**REQ-OPS-010** (Ubiquitous): Release builds of XPE DLLs and ImageProcTest.exe shall be reproducible: identical source tree + identical toolchain + identical environment produces bit-identical output.
+
+**REQ-OPS-011** (Ubiquitous): Build scripts SHALL honor SOURCE_DATE_EPOCH environment variable for embedded timestamps.
+
+**REQ-OPS-012** (Ubiquitous): CMake configuration SHALL disable non-deterministic features (e.g., __DATE__, __TIME__ macros) in production builds.
+
+**REQ-OPS-013** (Ubiquitous): A verification script `scripts/verify_reproducible.sh` shall run dual-build comparison on CI and report any byte-level divergence.
+
+**REQ-OPS-014** (Ubiquitous): Any known unavoidable non-determinism (e.g., PDB timestamps on Windows) SHALL be documented in `docs/operations/reproducibility-exceptions.md`.
+
+### 4.3 Data/Concept Drift Detection (Should)
+
+**REQ-OPS-020** (Ubiquitous): AI modules (PRE-06 ML, POST-02 DL, POST-07 AI, POST-09 Bone Suppression) SHALL emit input-distribution fingerprints at inference time for drift analysis.
+
+**REQ-OPS-021** (Ubiquitous): Drift detection pipeline SHALL support at minimum: (a) Kolmogorov-Smirnov test per-feature, (b) Maximum Mean Discrepancy (deep kernel), (c) classifier-based drift detector per Nature Digital Medicine 2024.
+
+**REQ-OPS-022** (Event-driven): When drift metric exceeds site-configured threshold, the system shall emit a drift alert in telemetry stream and optionally trigger PCCP-authorized retraining per SPEC-XPE-REG §4.1.
+
+**REQ-OPS-023** (Ubiquitous): Drift detector shall be configurable off-device (cloud analyst) or on-device (edge) per deployment scenario.
+
+**REQ-OPS-024** (Ubiquitous): Drift artifacts (fingerprints, scores) SHALL be encoded in privacy-preserving manner: no raw pixel data leaves the device boundary.
+
+### 4.4 OpenTelemetry Instrumentation (Should)
+
+**REQ-OPS-030** (Ubiquitous): xpe_common.dll SHALL provide OTEL Tracer/Meter/Logger API wrapper compatible with OpenTelemetry 1.x specification.
+
+**REQ-OPS-031** (Ubiquitous): OTEL instrumentation shall be opt-in (off by default) controlled via configuration flag `xpe_config.observability.otel_enabled`.
+
+**REQ-OPS-032** (Ubiquitous): When enabled, OTEL spans shall be emitted for: pipeline stage boundaries, AI inference, DICOM network transactions, errors.
+
+**REQ-OPS-033** (Ubiquitous): OTEL metrics shall include: processing time per stage, AI confidence distribution, DICOM I/O latency, error rate per SWU.
+
+**REQ-OPS-034** (Ubiquitous): OTEL Profiling signal (introduced 2024) SHOULD be supported for continuous profiling when enabled.
+
+**REQ-OPS-035** (Ubiquitous): OTEL Exporter shall support OTLP over HTTP/protobuf at minimum; OTLP/gRPC and Zipkin/Jaeger as options.
+
+**REQ-OPS-036** (Ubiquitous): OTEL span/metric names SHALL follow semantic conventions (e.g., `xpe.stage.name`, `xpe.swu.id`).
+
+### 4.5 Reject-Analysis Telemetry (Should · score-plan 반영)
+
+**REQ-OPS-040** (Ubiquitous): When a study is marked by a technologist as "rejected" (requiring re-acquisition), the system shall capture: reason code (positioning, exposure, motion, artifact, other), anatomical region, exposure parameters, device identifier, timestamp.
+
+**REQ-OPS-041** (Ubiquitous): Reject-analysis data shall be aggregatable across the deployed fleet while preserving patient privacy.
+
+**REQ-OPS-042** (Ubiquitous): Reject rate dashboard shall support breakdown by: reason, anatomy, device, technologist (opt-in per site policy).
+
+**REQ-OPS-043** (Ubiquitous): Reject-analysis reports align with AAPM TG-151 Ongoing QC methodology.
+
+### 4.6 Deviation Index (DI) Drift Telemetry (Should · score-plan 반영)
+
+**REQ-OPS-050** (Ubiquitous): The xpe_enhance_basic.dll DI/EI output per IEC 62494-1 SHALL emit telemetry event per processed study.
+
+**REQ-OPS-051** (Ubiquitous): DI drift monitor shall compute site-specific baseline distribution during first 30 days then alert on deviation beyond 2 sigma.
+
+**REQ-OPS-052** (Ubiquitous): DI drift events SHALL be correlated with reject-analysis patterns to identify systematic mis-exposure.
+
+### 4.7 VEX Automation (Should · cross-ref SEC)
+
+**REQ-OPS-060** (Event-driven): When a CVE is published affecting an SBOM component of XPE, the VEX automation pipeline shall trigger within 24 hours.
+
+**REQ-OPS-061** (Ubiquitous): VEX automation shall include: (a) affected version check, (b) exploitability analysis using upstream advisory + local code analysis, (c) VEX document generation in CycloneDX VEX, OpenVEX, and CSAF 2.0 formats.
+
+**REQ-OPS-062** (Ubiquitous): VEX documents SHALL be published at `https://github.com/holee9/image-processing/security/advisories/` and referenced in SBOM updates.
+
+**REQ-OPS-063** (Ubiquitous): VEX status shall be one of: `affected`, `not_affected`, `fixed`, `under_investigation`.
+
+### 4.8 Customer Feedback Loop
+
+**REQ-OPS-070** (Ubiquitous): A customer feedback channel SHALL be provided per MDR Annex III §1.1.
+
+**REQ-OPS-071** (Ubiquitous): Feedback items SHALL be triaged within 10 business days and categorized: complaint, feature request, documentation, other.
+
+**REQ-OPS-072** (Event-driven): When a complaint meeting "serious incident" definition is received, §4.1 REQ-OPS-004 notification workflow activates.
+
+### 4.9 Operational Runbooks
+
+**REQ-OPS-080** (Ubiquitous): Runbooks SHALL exist for: installation, upgrade, rollback, incident response, drift alert, reject rate anomaly, audit log collection.
+
+**REQ-OPS-081** (Ubiquitous): Runbooks shall be version-controlled and reviewed at each major release.
+
+---
+
+## 5. Acceptance Criteria
+
+### 5.1 PMS Artifacts
+
+- [ ] PMS Plan document approved by Quality/Regulatory
+- [ ] PSUR template prepared
+- [ ] Serious incident notification workflow tested (tabletop)
+- [ ] Competent authority contact list maintained
+
+### 5.2 Reproducibility
+
+- [ ] Two CI runs of identical tag produce bit-identical artifacts
+- [ ] SLSA L2+ attestation generated (cross-ref SEC §4.5)
+- [ ] Exception list for unavoidable non-determinism documented
+
+### 5.3 Drift Detection
+
+- [ ] Drift detector pipeline prototyped for 1 AI module (PRE-06 ML)
+- [ ] Three detector algorithms (KS, MMD, classifier) implemented with unit tests
+- [ ] Alert threshold calibration guide published
+
+### 5.4 OpenTelemetry
+
+- [ ] xpe_common exports OTEL Tracer/Meter/Logger API
+- [ ] ImageProcTest demonstrates end-to-end tracing
+- [ ] OTLP exporter validated against Jaeger and Grafana Tempo
+
+### 5.5 Reject-Analysis
+
+- [ ] Reject event schema defined (JSON schema published)
+- [ ] ImageProcTest reject dialog integrated
+- [ ] Aggregation dashboard prototype
+
+### 5.6 VEX
+
+- [ ] VEX automation workflow `.github/workflows/vex.yml` functional
+- [ ] Sample VEX documents published for known CVEs
+
+---
+
+## 6. Out-of-Scope Clarifications
+
+- Cloud backend for aggregation → site IT decision, XPE emits only
+- Commercial observability platforms (Datadog, New Relic) → supported via OTLP, not specific integration
+- Complete FHIR bulk export → SPEC-XPE-IOP scope
+- Device management (MDM/EMM) → out of scope
+
+---
+
+## 7. Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|:--------:|-----------|
+| OTEL overhead impacts real-time pipeline | Medium | Sampling + opt-in default off + benchmark harness |
+| Reproducibility blockers on Windows (PDB, /Brepro) | Medium | Use `/Brepro` linker flag; document residual non-determinism |
+| Drift alert false positive fatigue | Medium | Conservative threshold + multi-algorithm consensus |
+| PMS data aggregation privacy concerns | High | Federated/anonymized metrics; no raw pixel egress |
+| Reject-analysis gaming (users disable reject) | Low | Audit log immutability; technologist training |
+| MHRA PMS short timelines | Medium | Automated notification pipeline with template |
+
+---
+
+## 8. Deliverables
+
+### 8.1 Documents (10)
+
+1. `docs/operations/pms-plan.md`
+2. `docs/operations/psur-template.md`
+3. `docs/operations/serious-incident-workflow.md`
+4. `docs/operations/reproducibility-plan.md`
+5. `docs/operations/reproducibility-exceptions.md`
+6. `docs/operations/drift-detection-design.md`
+7. `docs/operations/otel-instrumentation-guide.md`
+8. `docs/operations/reject-analysis-spec.md`
+9. `docs/operations/runbooks/` (8 runbooks)
+10. `docs/operations/vex-automation-design.md`
+
+### 8.2 Code Artifacts
+
+- Header: `modules/common/include/xpe/common/xpe_otel.h`
+- Header: `modules/common/include/xpe/common/xpe_telemetry.h` (drift, reject, DI events)
+- Implementation: `modules/common/src/xpe_otel.cpp`, `xpe_telemetry.cpp`
+- Tests: `modules/common/tests/test_otel.cpp`, `test_telemetry.cpp`
+- Scripts: `scripts/verify_reproducible.sh`, `scripts/emit_vex.py`
+- CI: `.github/workflows/reproducible-build.yml`, `.github/workflows/vex.yml`
+
+### 8.3 RTM Entries
+
+- 30+ REQ-OPS-XXX entries
+
+---
+
+## 9. Dependencies
+
+- **Upstream**: SPEC-XPE-MASTER v3.0.0, SPEC-XPE-REG v1.0, SPEC-XPE-SEC v1.0, S0-B (xpe_common)
+- **Downstream**: All AI modules (drift detectors), all DLL modules (OTEL instrumentation)
+- **External**: OpenTelemetry Collector/Gateway, VEX registry (GitHub, OSV.dev)
+
+---
+
+## 10. Change Control
+
+- PMS Plan review: every 12 months or on significant regulatory change
+- Drift threshold review: quarterly based on field data
+- Runbook updates: on each major release
+
+---
+
+**본 SPEC은 XPE의 운영·관측성·판매 후 감시 마스터로서 EU MDR Article 83과 FDA AI 판매 후 모니터링 요건을 구현한다.**

--- a/.moai/specs/SPEC-XPE-P3-AI/spec.md
+++ b/.moai/specs/SPEC-XPE-P3-AI/spec.md
@@ -1,0 +1,358 @@
+# SPEC-XPE-P3-AI: AI Module v1.0 (Self-Supervised + Diffusion + XAI + Conformal UQ)
+
+---
+id: SPEC-XPE-P3-AI
+version: 1.1.0
+status: Draft
+created: 2026-04-17
+updated: 2026-04-17
+author: MoAI (manager-spec orchestration)
+priority: Should (전체). Phase 3 AI-DSF 배포 승인 시 baseline governance 부분만 조건부 Must 승격
+issue_number: null
+iec62304_class: B
+development_mode: TDD
+sprint: S3 (Phase 3 AI, 조건부 진입)
+dependency: SPEC-XPE-MASTER v3.0.0, SPEC-XPE-REG v1.1, SPEC-XPE-SEC v1.1, SPEC-XPE-OPS v1.1, SPEC-XPE-P2-ADV v1.0, S2-A 완료
+---
+
+## Priority Reclassification Notice (v1.1)
+
+본 SPEC 전체는 trend-survey-2026.md v1.1에서 **Should**로 재분류:
+
+- **강등 근거**: AI 모듈(xpe_ai.dll)은 Phase 3 기능. 결정적 전용 Phase 1/2 릴리스는 본 SPEC 비해당 → 출시 블로커 아님
+- **조건부 Must 승격**: Phase 3 AI-DSF 배포를 공식 결정하고 FDA/EU 제출 계획이 확정되면 다음 항목은 Must로 승격:
+  - REQ-AI-010~012 (Model Card) — FDA Transparency 대응
+  - REQ-AI-013 (Data Lineage) — GMLP Principle #3
+  - REQ-AI-002 (Deterministic Fallback) — 의료기기 안전 기본
+  - REQ-AI-110~112 (PCCP Boundary) — FDA PCCP 대응
+- **현재 실행 범위**: Phase 2 완료 후 Phase 3 진입 결정 시 재평가
+
+## HISTORY
+
+| Version | Date       | Author       | Changes                                   |
+|---------|------------|--------------|-------------------------------------------|
+| 1.0.0   | 2026-04-17 | MoAI         | Initial SPEC replacing legacy S3-AI draft. SSL denoising + Diffusion priors + XAI sidecar + Conformal UQ + PCCP linkage |
+
+---
+
+## 1. Scope
+
+### 1.1 Overview
+
+본 SPEC은 XPE Phase 3 AI 모듈(xpe_ai.dll)의 구현 명세이다. SPEC-XPE-P2-ADV에서 확립된 deterministic premium tier 위에 AI 계층을 assistive 역할로 추가한다. 모든 AI 기능은 **deterministic fallback 필수**, **opt-in 기본 비활성**, **sidecar 메타데이터 전달**, **PCCP 범위 내 변경만 허용** 원칙을 준수한다.
+
+### 1.2 In Scope — Baseline AI (Must)
+
+- **AI-B-01**: Model Card API (REQ-REG-020~023 구현)
+- **AI-B-02**: Data Lineage recorder
+- **AI-B-03**: Deterministic fallback router (REQ-REG-AI-03 구현)
+- **AI-B-04**: ONNX Runtime 1.20+ integration with multi-EP (CPU, CUDA, TensorRT, DirectML)
+- **AI-B-05**: Model versioning + PCCP boundary enforcement
+- **AI-B-06**: Input validation + adversarial robustness basic
+
+### 1.3 In Scope — Differentiator AI (Should)
+
+- **AI-D-01**: Self-Supervised Denoising (Noise2Noise / Noise2Self / Neighbor2Neighbor family) — POST-02
+- **AI-D-02**: Diffusion Priors for Low-Dose Enhancement (NEED / DiffDenoise / SAD) — POST-02 premium
+- **AI-D-03**: ML Defect Correction (PRE-06 ML) with ViT AE
+- **AI-D-04**: Bone Suppression U-Net (POST-09)
+- **AI-D-05**: AI Collimation Detection (POST-07 AI variant)
+- **AI-D-06**: XAI Sidecar (Grad-CAM saliency, SHAP feature attribution)
+- **AI-D-07**: Conformal Prediction Uncertainty Quantification
+
+### 1.4 Exclusions
+
+- Foundation model fine-tuning (MedSAM, RadImageGAN) → Could tier / Phase 4
+- Federated learning → Could / Post-market
+- Generative data augmentation → Could / research mode
+- Continuous online learning → regulatory boundary risk, excluded
+- LLM-based report generation → out of scope
+- Non-radiographic AI (CT, MRI specific) → out of scope
+
+---
+
+## 2. Referenced Documents
+
+| Document ID | Title | Role |
+|-------------|-------|------|
+| SPEC-XPE-REG | Regulatory Master | Governance normative |
+| SPEC-XPE-SEC | Cybersecurity Master | Security normative |
+| SPEC-XPE-OPS | Operations Master | Drift normative |
+| SPEC-XPE-IOP | Interoperability Master | AI SR encoding |
+| SPEC-XPE-P2-ADV | Advanced Post-Processing | Upstream pipeline |
+| SPEC-XPE-MASTER | XPE Master v3.0.0 | Upstream |
+| Noise2Sim (PMC) | Similarity-based SSL denoising | Reference |
+| Noise2Detail (MICCAI 2025) | Multistage N2N | Reference |
+| NEED (2025) | Noise-inspired Diffusion | Reference |
+| SAD (2024) | Structure-Aware Diffusion | Reference |
+| DiffDenoise (2025) | Conditional Diffusion denoising | Reference |
+| MedSAM2 (2025-04) | Segment Anything Medical | Reference (informative) |
+| Conformal Prediction Medical AI | Nature Digital Med 2024 | Reference |
+
+---
+
+## 3. Definitions
+
+| Term | Definition |
+|------|-----------|
+| SSL | Self-Supervised Learning |
+| N2N | Noise2Noise |
+| N2S | Noise2Self |
+| N2V | Noise2Void |
+| ViT | Vision Transformer |
+| AE | Autoencoder |
+| CP | Conformal Prediction |
+| XAI | Explainable AI |
+| SHAP | Shapley Additive Explanations |
+| Grad-CAM | Gradient-weighted Class Activation Mapping |
+| Sidecar | Auxiliary metadata alongside image |
+| PCCP Boundary | Allowed retraining scope without new FDA submission |
+| Execution Provider (EP) | ONNX Runtime backend (CPU, CUDA, TensorRT, DirectML) |
+| Worker Isolation | AI inference runs in isolated process |
+| Assistive AI | AI augments deterministic path, never replaces |
+
+---
+
+## 4. Requirements
+
+### 4.1 Architecture Principles (Must)
+
+**REQ-AI-001** (Ubiquitous): The xpe_ai.dll shall be Layer 1 (depends only on xpe_common.dll); no lateral Layer 1 dependencies.
+
+**REQ-AI-002** (Ubiquitous): All AI inference shall have a deterministic fallback path that maintains clinical usability when AI is disabled, fails, or confidence is below threshold.
+
+**REQ-AI-003** (Ubiquitous): AI modules shall run in worker-isolated architecture: inference in separate process, IPC via shared memory or pipe, main process crash-immune.
+
+**REQ-AI-004** (Ubiquitous): AI metadata SHALL be delivered via sidecar (not mutating XpeImageMetadata) per SPEC-XPE-MASTER v3.0 Sidecar Contract.
+
+**REQ-AI-005** (Ubiquitous): AI execution shall be opt-in per pipeline configuration; default off until explicit activation.
+
+**REQ-AI-006** (Ubiquitous): ONNX Runtime 1.20+ SHALL be the model runtime. Execution Provider selection shall be configurable: CPU (always), CUDA (x86 GPU), TensorRT (NVIDIA), DirectML (Windows GPU).
+
+**REQ-AI-007** (Ubiquitous): Model files (.onnx) SHALL be signed (Ed25519 or ECDSA P-256) and verified at load time.
+
+**REQ-AI-008** (Ubiquitous): Model versioning shall follow semver; model metadata shall include: model_id, version, pccp_scope, training_data_hash, validation_metrics.
+
+### 4.2 Model Card & Transparency (Must · cross-ref REG)
+
+**REQ-AI-010** (Ubiquitous): For each AI model, `xpe_ai_get_model_card(model_id, buf, buf_size)` shall return JSON with: intended_use, training_data_summary, demographic_performance, limitations, model_version, pccp_status, published_date.
+
+**REQ-AI-011** (Ubiquitous): Model card JSON shall conform to schema `schemas/model-card.schema.json`.
+
+**REQ-AI-012** (Event-driven): When AI inference confidence is below threshold (configurable, default 0.6), the system shall emit a low-confidence event and fall back to deterministic path.
+
+### 4.3 Self-Supervised Denoising (Should · POST-02)
+
+**REQ-AI-020** (Ubiquitous): The POST-02 AI tier shall implement a self-supervised denoising model trainable without clean reference images.
+
+**REQ-AI-021** (Ubiquitous): Supported SSL training strategies: Noise2Noise (N2N), Noise2Self (N2S), Neighbor2Neighbor, Noise2Sim (similarity-based).
+
+**REQ-AI-022** (Ubiquitous): SSL model inference latency target: ≤ 500 ms per 3000x3000 image on CPU, ≤ 100 ms on GPU (TensorRT).
+
+**REQ-AI-023** (Ubiquitous): SSL model quality shall be benchmarked against deterministic MFP (SPEC-XPE-P2-ADV §4.1) on matched phantom sets; pass criteria PSNR ≥ matched, SSIM ≥ matched, FROC AUC ≥ 0.95 of matched.
+
+**REQ-AI-024** (Ubiquitous): SSL training data shall include phantom and anonymized clinical images per site agreement; data lineage recorded per REQ-REG-013.
+
+### 4.4 Diffusion Priors Enhancement (Should · POST-02 premium)
+
+**REQ-AI-030** (Ubiquitous): Optional diffusion-prior enhancement tier SHALL be provided as opt-in premium path.
+
+**REQ-AI-031** (Ubiquitous): Supported strategies: NEED (Noise-Inspired Diffusion), SAD (Structure-Aware Diffusion), DiffDenoise (Conditional Diffusion).
+
+**REQ-AI-032** (Ubiquitous): Diffusion tier latency target: ≤ 5 s per image on GPU (configurable DDIM steps).
+
+**REQ-AI-033** (Ubiquitous): Diffusion tier shall document perceptual benefit over SSL baseline via user study or radiologist reader study (reference: Medical Physics 2025 methodology).
+
+### 4.5 ML Defect Correction — PRE-06 (Should)
+
+**REQ-AI-040** (Ubiquitous): ML defect correction shall use ViT Autoencoder-based model per existing Panel Defect PRD.
+
+**REQ-AI-041** (Ubiquitous): ML tier quality target: NMSE ≥ 14x improvement over basic interpolation (existing Panel Defect PRD target).
+
+**REQ-AI-042** (Ubiquitous): ML defect correction shall emit class-aware routing decision (defect_type: hot, dead, cluster) as sidecar metadata.
+
+### 4.6 Bone Suppression — POST-09 (Should)
+
+**REQ-AI-050** (Ubiquitous): Bone Suppression shall use U-Net architecture trained on DES (Dual Energy Subtraction) paired data.
+
+**REQ-AI-051** (Ubiquitous): Bone Suppression quality target: pulmonary nodule sensitivity +16.8% over non-suppressed (Phase 2 brainstorming target).
+
+**REQ-AI-052** (Ubiquitous): Bone Suppression shall emit IHE AIR-compatible DICOM SR (cross-ref SPEC-XPE-IOP §4.4.4).
+
+### 4.7 AI Collimation Detection — POST-07 AI variant (Should)
+
+**REQ-AI-060** (Ubiquitous): AI collimation detection shall augment POST-07 baseline Hough-based detection.
+
+**REQ-AI-061** (Ubiquitous): AI confidence below threshold shall trigger fallback to Hough deterministic path.
+
+**REQ-AI-062** (Ubiquitous): AI-refined ROI shall be delivered via sidecar JSON (cross-ref SPEC-XPE-MASTER v3.0).
+
+### 4.8 Explainable AI Sidecar (Should · cross-ref REG)
+
+**REQ-AI-070** (Ubiquitous): XAI sidecar generation shall be opt-in per inference.
+
+**REQ-AI-071** (Ubiquitous): Supported XAI methods: Grad-CAM (gradient-based saliency), SHAP (feature attribution for tabular-features AI).
+
+**REQ-AI-072** (Ubiquitous): XAI sidecar JSON shall include: method, model_id, version, saliency_map_reference (DICOM UID or file path), confidence, disclaimer text.
+
+**REQ-AI-073** (Ubiquitous): XAI disclaimer shall warn: "Post-hoc explanations may not reflect actual decision process; use as hint, not diagnostic justification" per BMC Medical Imaging Systematic Review 2025.
+
+### 4.9 Conformal Prediction UQ (Should)
+
+**REQ-AI-080** (Ubiquitous): For classification-like AI outputs (bone vs no-bone, defect class), conformal prediction sets with coverage guarantee α (default 0.90) shall be provided.
+
+**REQ-AI-081** (Ubiquitous): CP calibration set shall be maintained separately from training and independent test sets.
+
+**REQ-AI-082** (Ubiquitous): Prediction set size and coverage shall be reported per inference in sidecar metadata.
+
+**REQ-AI-083** (Ubiquitous): Conformal Ordinal variant (arXiv 2207.02238) SHALL be supported for severity rating tasks.
+
+### 4.10 Adversarial Robustness & Security (Must · cross-ref SEC)
+
+**REQ-AI-090** (Ubiquitous): AI input validation shall include: image dimension bounds, pixel value bounds, DICOM metadata schema check.
+
+**REQ-AI-091** (Ubiquitous): AI model loading shall verify Ed25519/ECDSA signature (REQ-AI-007).
+
+**REQ-AI-092** (Ubiquitous): AI inference shall enforce time budget (configurable, default 5s); exceeding budget triggers fallback and alert.
+
+**REQ-AI-093** (Ubiquitous): AI inference process shall run with minimum privilege (no network, no file write except sidecar scratch).
+
+### 4.11 Drift Detection (Should · cross-ref OPS)
+
+**REQ-AI-100** (Ubiquitous): AI modules shall emit input fingerprints per REQ-OPS-020.
+
+**REQ-AI-101** (Event-driven): When drift alert triggers per REQ-OPS-022, AI modules shall tag subsequent inferences with `drift_flagged: true` in sidecar.
+
+### 4.12 PCCP Boundary Enforcement (Must · cross-ref REG)
+
+**REQ-AI-110** (Ubiquitous): At model load time, PCCP metadata shall be verified against deployed AI-DSF module's authorized PCCP.
+
+**REQ-AI-111** (Event-driven): If a model's PCCP scope exceeds the authorized one, the model shall fail to load with error `XPE_ERR_PCCP_EXCEEDED`.
+
+**REQ-AI-112** (Ubiquitous): Model audit event (per REQ-REG-007) shall be emitted at each model load/unload.
+
+---
+
+## 5. Acceptance Criteria
+
+### 5.1 Core Infrastructure
+
+- [ ] xpe_ai.dll Layer 1 conformance verified
+- [ ] Worker-isolated inference architecture functional
+- [ ] ONNX Runtime 1.20+ integration with 4 EPs
+- [ ] Model signing/verification pipeline
+- [ ] Deterministic fallback router tested for 100% coverage
+
+### 5.2 SSL Denoising
+
+- [ ] Noise2Noise baseline model trained on phantom + clinical
+- [ ] Benchmark report vs. MFP baseline published
+- [ ] Inference latency meets REQ-AI-022
+
+### 5.3 Diffusion
+
+- [ ] At least one diffusion backend (NEED/DiffDenoise) deployed
+- [ ] Reader study protocol drafted
+- [ ] Opt-in activation tested
+
+### 5.4 ML Defect / Bone Suppression / AI Collimation
+
+- [ ] Each module passes quality thresholds (REQ-AI-041, 051, 061)
+- [ ] Each module emits sidecar metadata
+- [ ] Each module integrates AIR DICOM SR (cross-ref IOP)
+
+### 5.5 XAI + UQ
+
+- [ ] Grad-CAM sidecar generation functional
+- [ ] Conformal prediction sets with validated coverage α=0.90 ± 0.02
+
+### 5.6 Regulatory & Security
+
+- [ ] Model Card API conformant to schema
+- [ ] PCCP enforcement tested with boundary violations
+- [ ] Adversarial input fuzzing passes
+
+### 5.7 Post-Market
+
+- [ ] Drift fingerprint emission on every inference
+- [ ] Audit log integrity verified
+
+---
+
+## 6. Out-of-Scope Clarifications
+
+- Training infrastructure (GPU farm) → separate ops concern
+- Model repository/registry → separate ops concern (MLOps)
+- Cloud inference endpoints → not in initial scope
+- Multi-modal AI (text + image) → not in scope
+- Real-time continuous training → excluded per §1.4
+
+---
+
+## 7. Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|:--------:|-----------|
+| Model performance regression post-PCCP update | High | Canary validation, regression test gate, auto-rollback |
+| XAI misleads clinician (false explanation) | Medium | Disclaimer + user education; limit to supplementary |
+| Diffusion hallucination risk | High | Benchmark gate + degraded mode; restrict to premium opt-in |
+| Adversarial attacks | Medium | Input validation + signed models + isolated worker |
+| Training data leakage | High | Data lineage audit + de-identification verification |
+| TensorRT EP instability on new drivers | Medium | Fall back to CUDA EP or CPU EP; multi-EP test matrix |
+| Large model file distribution | Medium | CDN + signature verification; SBOM inclusion |
+
+---
+
+## 8. Deliverables
+
+### 8.1 Code Artifacts
+
+- `modules/ai/include/xpe/ai/xpe_ai_api.h` (~15 API functions)
+- `modules/ai/src/xpe_ai_core.cpp`
+- `modules/ai/src/xpe_ai_ssl_denoise.cpp`
+- `modules/ai/src/xpe_ai_diffusion.cpp`
+- `modules/ai/src/xpe_ai_ml_defect.cpp`
+- `modules/ai/src/xpe_ai_bone_suppress.cpp`
+- `modules/ai/src/xpe_ai_collimation.cpp`
+- `modules/ai/src/xpe_ai_xai.cpp`
+- `modules/ai/src/xpe_ai_cp.cpp`
+- `modules/ai/src/xpe_ai_worker.cpp` (isolation)
+- `modules/ai/tests/` (≥ 80% coverage)
+- `models/` directory with signed .onnx files
+
+### 8.2 Training Recipes
+
+- `training/ssl/noise2noise_recipe.py`
+- `training/ssl/noise2self_recipe.py`
+- `training/diffusion/need_recipe.py`
+- `training/ml_defect/vit_ae_recipe.py`
+- `training/bone_suppression/unet_recipe.py`
+- `training/conformal/calibration_recipe.py`
+
+### 8.3 Documents
+
+- `docs/ai/ai-architecture.md`
+- `docs/ai/ai-quality-benchmarks.md`
+- `docs/ai/xai-usage-guide.md`
+- `docs/ai/conformal-prediction-guide.md`
+- `docs/ai/reader-study-protocol.md`
+
+---
+
+## 9. Dependencies
+
+- **Upstream (hard)**: SPEC-XPE-MASTER v3.0.0, SPEC-XPE-REG v1.0, SPEC-XPE-SEC v1.0, SPEC-XPE-OPS v1.0, SPEC-XPE-P2-ADV v1.0 완료, S0-B (xpe_common) 완료
+- **Upstream (soft)**: SPEC-XPE-IOP v1.0 (AI SR encoding), training data availability
+- **External**: ONNX Runtime 1.20+, PyTorch 2.x training, GPU infra
+
+---
+
+## 10. Change Control
+
+- Model updates: per PCCP §4.12
+- New AI module addition: new SPEC variant (P3-AI-vN)
+- XAI method addition: Should-tier, requires clinical justification
+
+---
+
+**본 SPEC은 XPE의 Phase 3 AI 구현 마스터로서 PCCP/GMLP/EU AI Act 준수와 최신 2024-2026 SSL·Diffusion·UQ 트렌드를 반영한다.**

--- a/.moai/specs/SPEC-XPE-REG/spec.md
+++ b/.moai/specs/SPEC-XPE-REG/spec.md
@@ -1,0 +1,335 @@
+# SPEC-XPE-REG: Regulatory Master Compliance
+
+---
+id: SPEC-XPE-REG
+version: 1.1.0
+status: Draft
+created: 2026-04-17
+updated: 2026-04-17
+author: MoAI (manager-spec orchestration)
+priority: Mixed (Must for M-01~M-03 core; Should for AI-related REG-03~07 deferred to Phase 3)
+issue_number: null
+iec62304_class: B
+development_mode: TDD
+sprint: S-REG-CORE (Must) + S-REG-AI (Should, Phase 3 승인 시)
+dependency: SPEC-XPE-MASTER v3.0.0, trend-survey-2026.md v1.1
+---
+
+## Priority Reclassification Notice (v1.1)
+
+본 SPEC의 우선순위는 trend-survey-2026.md v1.1 엄격 재분류에 따라 다음과 같이 혼합:
+
+- **Must (즉시 착수)**: IEC 62304 Class B 문서, EU MDR 준수, 21 CFR 820.30 + QMSR 2026
+- **Should (Phase 3 AI 승인 시 Must 승격)**: FDA PCCP, FDA AI-DSF Lifecycle Draft, FDA Transparency, IMDRF GMLP, EU AI Act High-Risk, ISO/IEC 42001 AIMS
+- **현재 실행 범위**: Must 부분만 즉시, Should 부분은 Phase 3 진입 결정 시 본 SPEC이 전체 Must로 승격
+
+## HISTORY
+
+| Version | Date       | Author       | Changes                                   |
+|---------|------------|--------------|-------------------------------------------|
+| 1.0.0   | 2026-04-17 | MoAI         | Initial EARS SPEC integrating FDA PCCP / AI-DSF Lifecycle / Transparency / IMDRF GMLP / EU AI Act / ISO 42001 / IEC 62304/81001-5-1 / QMSR |
+
+---
+
+## 1. Scope
+
+### 1.1 Overview
+
+본 SPEC은 XPE 프로젝트의 **규제 준수 마스터 문서**로서, 2024-2026년 발효·시행된 AI/ML 의료기기 규제를 단일 통합 프레임워크로 정리한다. 본 문서는 IEC 62304(기본 소프트웨어 라이프사이클)에 **상위 오버레이**로 기능하며, 4개 하위 레거시 SPEC(P0/P1A/P2-ADV/P3-AI)을 규제 축으로 재구성한다.
+
+본 SPEC이 다루는 7개 규제 축:
+
+1. **FDA PCCP** (Predetermined Change Control Plan) — Final Guidance 2024-12
+2. **FDA AI-DSF Lifecycle** (Total Product Life Cycle) — Draft Guidance 2025-01
+3. **FDA Transparency for ML-MD** — Guiding Principles 2024-06
+4. **IMDRF GMLP N88** (10 Guiding Principles) — Final 2025-01
+5. **EU AI Act** (Regulation 2024/1689) — High-Risk Medical AI Compliance
+6. **ISO/IEC 42001** (AI Management System) — 2023-12
+7. **QMSR 2026** (Quality Management System Regulation, ISO 13485 통합)
+
+### 1.2 In Scope
+
+- Regulatory Traceability Matrix (XPE SWU ↔ FDA/EU/ISO 요구사항 매핑)
+- Model Card 및 Transparency Artifact 스펙
+- PCCP 프레임워크 (재훈련 sanction 경로)
+- AI Management System (ISO 42001) 프로세스 정의
+- 인간-AI 상호작용 설계 원칙 (GMLP #5, #6)
+- Data Lineage 및 Bias Analysis 프로토콜
+- QMSR 2026 전환 gap analysis
+- Submission Package Outline (FDA 510(k)/PMA + CE MDR)
+
+### 1.3 Exclusions
+
+- **Cybersecurity**: SPEC-XPE-SEC 범위 (FDA §524B, IEC 81001-5-1)
+- **Interoperability**: SPEC-XPE-IOP 범위 (DICOM, FHIR, IHE)
+- **Operations/Post-Market Telemetry**: SPEC-XPE-OPS 범위
+- **AI Implementation Details**: SPEC-XPE-P3-AI 범위 (본 SPEC은 governance만)
+- **Cybersecurity Risk Management**: IEC 81001-5-1 항목은 SEC로 위임
+
+---
+
+## 2. Referenced Documents
+
+| Document ID | Title | Version | Role |
+|-------------|-------|---------|------|
+| FDA-PCCP-2024 | Marketing Submission Recommendations for PCCP for AI-DSF | Final 2024-12-03 | Normative |
+| FDA-AIDSF-2025 | AI-DSF Lifecycle Management and Marketing Submission Recommendations | Draft 2025-01-07 | Normative (공개 의견 기간 종료 2025-04-07) |
+| FDA-TRANS-2024 | Transparency for ML-Enabled MD: Guiding Principles | 2024-06 | Normative |
+| IMDRF-N88 | Good Machine Learning Practice for Medical Device Development: Guiding Principles | Final 2025-01-27 | Normative |
+| EU-2024-1689 | EU Artificial Intelligence Act | 2024-08-01 발효 | Normative (Medical AI 2027-08 전면) |
+| EU-2017-745 | Medical Devices Regulation (MDR) | 2017/745 + MDCG 2025 amendments | Normative |
+| ISO-42001 | AI Management System | 2023-12 | Normative |
+| IEC-62304 | Medical Device Software Life Cycle Processes | 2006 + Amd.1:2015 | Normative (기존) |
+| ISO-13485 | Medical Devices QMS | 2016 | Normative (QMSR 2026 통합) |
+| ISO-14971 | Risk Management for Medical Devices | 2019 | Normative |
+| NIST-AI-100-1 | AI Risk Management Framework | 1.0 (2023-01) | Informative Reference |
+| NIST-AI-600-1 | Gen AI Profile | 2024-07-26 | Informative Reference |
+| SPEC-XPE-MASTER | XPE Master Implementation Plan | v3.0.0 | Upstream |
+| TREND-SURVEY-2026-001 | XPE Trend Survey & Matrix | v1.0.0 | Upstream |
+
+---
+
+## 3. Definitions and Acronyms
+
+| Term | Definition |
+|------|-----------|
+| PCCP | Predetermined Change Control Plan — AI 모델 재훈련에 대한 사전 승인 계획 |
+| AI-DSF | Artificial Intelligence-Enabled Device Software Function (FDA 2024-12 이후 용어) |
+| ML-DSF | Machine Learning-Enabled Device Software Function (구 용어, AI-DSF로 대체) |
+| TPLC | Total Product Life Cycle — FDA의 전생애주기 관리 접근 |
+| GMLP | Good Machine Learning Practice — IMDRF/FDA 10대 원칙 |
+| AIMS | Artificial Intelligence Management System — ISO 42001 기반 |
+| QMSR | Quality Management System Regulation — 2026 FDA ISO 13485 통합 |
+| High-Risk AI | EU AI Act Annex III/Article 6 — 의료기기 AI 자동 분류 |
+| Model Card | 모델 특성·성능·한계 투명성 문서 |
+| Data Lineage | 데이터 출처, 수집, 가공, 분할 이력 |
+| Substantial Modification | EU AI Act 재평가 트리거 |
+| Bias Analysis | 인구통계·장비별 성능 편차 분석 |
+| RTM | Requirements Traceability Matrix |
+
+---
+
+## 4. Requirements (EARS Format)
+
+### 4.1 FDA PCCP Requirements
+
+**REQ-REG-001** (Ubiquitous): The XPE system shall maintain a Predetermined Change Control Plan document for each AI-DSF module (PRE-06 ML, POST-02 DL, POST-07 AI, POST-09 Bone Suppression).
+
+**REQ-REG-002** (Ubiquitous): The PCCP document shall contain three components: (1) Description of Modifications, (2) Modification Protocol, (3) Impact Assessment.
+
+**REQ-REG-003** (State-driven): When an AI-DSF is subject to modification within the PCCP-authorized scope, the system shall not require a new 510(k) or PMA supplement.
+
+**REQ-REG-004** (State-driven): When an AI-DSF modification exceeds the PCCP-authorized scope, the system shall require new FDA submission.
+
+**REQ-REG-005** (Ubiquitous): The XPE device labeling shall state clearly that the device incorporates machine learning and has an authorized PCCP.
+
+**REQ-REG-006** (Ubiquitous): The PCCP shall specify test data, performance criteria, and regression boundaries for each permitted modification.
+
+**REQ-REG-007** (Event-driven): When a PCCP-authorized modification is executed, the system shall generate an audit record with version, training data snapshot hash, validation results, and deployment timestamp.
+
+### 4.2 FDA AI-DSF Lifecycle Requirements
+
+**REQ-REG-010** (Ubiquitous): Each AI-DSF shall have a Device Description document covering intended use, user, clinical environment, and patient population.
+
+**REQ-REG-011** (Ubiquitous): Each AI-DSF shall have a Model Description document covering architecture, inputs, outputs, training strategy.
+
+**REQ-REG-012** (Ubiquitous): Each AI-DSF shall document Data Management including collection, curation, labeling, splitting, and quality assurance processes.
+
+**REQ-REG-013** (Ubiquitous): Each AI-DSF shall maintain Data Lineage records identifying all training, validation, and test data sources.
+
+**REQ-REG-014** (Ubiquitous): Each AI-DSF submission shall include performance metrics tied to explicit clinical claims (sensitivity, specificity, AUC with 95% CI).
+
+**REQ-REG-015** (Ubiquitous): Each AI-DSF shall include a Bias Analysis across demographics (age, sex, race/ethnicity where available), equipment vendors, and acquisition protocols.
+
+**REQ-REG-016** (Ubiquitous): Each AI-DSF shall document Human-AI Interaction including user role, decision authority, override mechanism, and alert design.
+
+**REQ-REG-017** (Ubiquitous): Each AI-DSF shall include a Monitoring Plan identifying performance indicators to track post-deployment.
+
+### 4.3 FDA Transparency Requirements
+
+**REQ-REG-020** (Ubiquitous): The XPE system shall expose a Model Card API endpoint returning: intended use, training data summary, demographic performance, limitations, and model version.
+
+**REQ-REG-021** (Ubiquitous): The ImageProcTest GUI and end-user display shall present a Device Information screen showing AI components, model versions, and PCCP status.
+
+**REQ-REG-022** (Event-driven): When AI processing fails or confidence is below threshold, the system shall display a human-readable explanation including failure mode, fallback behavior, and recommended action.
+
+**REQ-REG-023** (Ubiquitous): Per-case XAI sidecar (if enabled) shall include model identifier, confidence score, and saliency map reference.
+
+### 4.4 IMDRF GMLP Requirements (10 Principles Mapping)
+
+**REQ-REG-030** (GMLP #1): The XPE system shall apply multi-disciplinary expertise throughout the total product lifecycle.
+
+**REQ-REG-031** (GMLP #2): Each AI-DSF shall implement good software engineering and security practices per IEC 62304 and IEC 81001-5-1.
+
+**REQ-REG-032** (GMLP #3): Clinical study participants and data sets shall be representative of the intended patient population.
+
+**REQ-REG-033** (GMLP #4): Training data sets shall be independent of test sets.
+
+**REQ-REG-034** (GMLP #5): Selected reference datasets shall be based upon best available methods.
+
+**REQ-REG-035** (GMLP #6): Model design shall be tailored to available data and reflect the intended use.
+
+**REQ-REG-036** (GMLP #7): Focus of the Human-AI Team is to perform well in the intended workflow.
+
+**REQ-REG-037** (GMLP #8): Testing shall demonstrate device performance during clinically relevant conditions.
+
+**REQ-REG-038** (GMLP #9): Users shall be provided clear, essential information about AI system performance and limitations.
+
+**REQ-REG-039** (GMLP #10): Deployed models shall be monitored for performance and re-training risks shall be managed.
+
+### 4.5 EU AI Act High-Risk Requirements
+
+**REQ-REG-050** (Ubiquitous): Each AI-DSF classified as High-Risk AI System under EU AI Act Article 6 shall comply with Chapter III Section 2 obligations.
+
+**REQ-REG-051** (Ubiquitous): The XPE provider shall maintain a Risk Management System per Article 9 (separate from ISO 14971 but harmonized).
+
+**REQ-REG-052** (Ubiquitous): Data governance per Article 10 shall ensure training/validation/test sets are relevant, representative, free of errors, and complete for intended purpose.
+
+**REQ-REG-053** (Ubiquitous): Technical documentation per Article 11 and Annex IV shall be maintained and updated through the lifecycle.
+
+**REQ-REG-054** (Ubiquitous): Record-keeping capabilities per Article 12 shall enable automatic recording of events throughout the lifetime of the system.
+
+**REQ-REG-055** (Ubiquitous): Transparency and information to users per Article 13 shall be provided via Instructions for Use.
+
+**REQ-REG-056** (Ubiquitous): Human oversight per Article 14 shall enable users to: (a) fully understand capacities and limitations, (b) remain aware of automation bias, (c) correctly interpret output, (d) decide not to use output, (e) reverse output, (f) interrupt the system.
+
+**REQ-REG-057** (Ubiquitous): Accuracy, robustness and cybersecurity per Article 15 shall be declared and continuously maintained.
+
+**REQ-REG-058** (Ubiquitous): The CE marking per Article 16 shall indicate conformity with both MDR and AI Act.
+
+### 4.6 ISO/IEC 42001 AI Management System Requirements
+
+**REQ-REG-070** (Ubiquitous): The organization shall establish an AI Management System (AIMS) per ISO/IEC 42001 Clauses 4-10.
+
+**REQ-REG-071** (Ubiquitous): AIMS shall be integrated with existing ISO 13485 QMS per Johner Institute dual-certification pattern.
+
+**REQ-REG-072** (Ubiquitous): AI-specific risk assessment shall identify opportunities and risks, and define risk-minimizing measures per ISO/IEC 42001 Clause 6.1.
+
+**REQ-REG-073** (Ubiquitous): AIMS shall document AI system lifecycle per ISO/IEC 42001 Annex B (36 controls).
+
+### 4.7 QMSR 2026 Transition Requirements
+
+**REQ-REG-080** (Ubiquitous): The XPE project shall complete a gap analysis from 21 CFR 820 QSR to QMSR (effective 2026-02-02) before FDA submission.
+
+**REQ-REG-081** (Ubiquitous): QMSR compliance shall include ISO 13485:2016 Clause 4-8 requirements.
+
+**REQ-REG-082** (Ubiquitous): Configuration management per ISO 13485 §7.5.9 shall explicitly frame SBOM as part of device configuration.
+
+### 4.8 Submission Package Requirements
+
+**REQ-REG-090** (Event-driven): When preparing FDA 510(k) or PMA submission, the submission package shall include: Device Description, Predicate Comparison (if 510(k)), PCCP, Model Card for each AI-DSF, Bias Analysis, Data Lineage, Validation Report, Cybersecurity Documentation (pointer to SEC SPEC), Usability Engineering File.
+
+**REQ-REG-091** (Event-driven): When preparing EU MDR Technical Documentation, the Annex II package shall include all Section 4.5 EU AI Act artifacts in addition to MDR Annex II contents.
+
+**REQ-REG-092** (Ubiquitous): Traceability Matrix (XPE-RTM-001) shall map each AI-DSF SWU to applicable FDA/EU/ISO requirements in this SPEC.
+
+---
+
+## 5. Acceptance Criteria
+
+### 5.1 Documentation Completeness
+
+- [ ] PCCP document exists for each AI-DSF (4 documents minimum: PRE-06, POST-02, POST-07, POST-09)
+- [ ] Model Card for each AI-DSF following FDA Transparency template
+- [ ] Data Lineage records for each training dataset
+- [ ] Bias Analysis report for each AI-DSF
+- [ ] EU AI Act Annex IV technical documentation
+- [ ] ISO/IEC 42001 AIMS Manual
+- [ ] QMSR gap analysis report
+- [ ] Updated RTM (XPE-RTM-001 v1.2) with REG mappings
+
+### 5.2 Process Gates
+
+- [ ] Legal counsel sign-off on regulatory interpretation
+- [ ] Clinical SME review of Model Cards
+- [ ] Data governance committee approval of data lineage
+
+### 5.3 API/Runtime Conformance
+
+- [ ] `xpe_ai_get_model_card()` C API returning Model Card JSON
+- [ ] `xpe_ai_get_version_info()` returning current model version, PCCP status
+- [ ] ImageProcTest GUI "AI Info" tab displays required information
+- [ ] Audit log records every AI-DSF modification event
+
+---
+
+## 6. Out-of-Scope Clarifications
+
+- Cybersecurity implementation (IEC 81001-5-1, §524B) → SPEC-XPE-SEC
+- DICOM/FHIR/IHE interoperability → SPEC-XPE-IOP
+- Post-market surveillance telemetry → SPEC-XPE-OPS
+- AI model code/training scripts → SPEC-XPE-P3-AI
+- Risk management file implementation → existing SRS-ENHANCE-ADV-001 + ISO 14971 process
+
+---
+
+## 7. Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|:--------:|-----------|
+| Legal interpretation error across FDA/EU/ISO | High | Legal counsel sign-off checkpoint at each SPEC-REG milestone |
+| EU AI Act 2027 timeline pressure | High | Start REG implementation in Sprint S-REG parallel to Phase 1a |
+| PCCP scope too restrictive or too broad | Medium | Iterate PCCP scope through regulatory pre-submission consultation (Q-Sub) |
+| QMSR transition surprises | Medium | Early gap analysis; external QMS audit before transition |
+| Bias analysis data unavailable | Medium | Use representative phantom datasets + limitation statement in Model Card |
+| AIMS vs QMS integration complexity | Medium | Follow Johner Institute dual-certification pattern |
+
+---
+
+## 8. Deliverables
+
+### 8.1 Documents (15)
+
+1. `docs/regulatory/pccp-pre-06.md` — PCCP for ML Defect Correction
+2. `docs/regulatory/pccp-post-02.md` — PCCP for DL Denoising
+3. `docs/regulatory/pccp-post-07.md` — PCCP for AI Collimation
+4. `docs/regulatory/pccp-post-09.md` — PCCP for Bone Suppression
+5. `docs/regulatory/model-card-template.md` — Template per FDA 2024-06
+6. `docs/regulatory/data-lineage-protocol.md`
+7. `docs/regulatory/bias-analysis-protocol.md`
+8. `docs/regulatory/eu-ai-act-annex-iv.md` — Technical documentation
+9. `docs/regulatory/iso-42001-aims-manual.md`
+10. `docs/regulatory/qmsr-gap-analysis.md`
+11. `docs/regulatory/human-ai-interaction-design.md`
+12. `docs/regulatory/fda-submission-outline.md` — 510(k)/PMA
+13. `docs/regulatory/ce-mdr-submission-outline.md`
+14. `docs/regulatory/regulatory-traceability-matrix.md` — Master RTM
+15. `docs/regulatory/substantial-modification-policy.md` — EU AI Act trigger
+
+### 8.2 Code Artifacts (minimal)
+
+- Header: `modules/common/include/xpe/common/xpe_model_card.h`
+- Implementation: `modules/common/src/xpe_model_card.cpp`
+- Test: `modules/common/tests/test_model_card.cpp`
+- GUI: `gui/ImageProcTest/Views/AiInfoTab.xaml` + code-behind
+
+### 8.3 RTM Entries
+
+- 40+ REQ-REG-XXX entries mapped to SWU-ai.* and SWU-5.x
+
+---
+
+## 9. Dependencies
+
+- **Upstream**: SPEC-XPE-MASTER v3.0.0, trend-survey-2026.md
+- **Downstream**: SPEC-XPE-P3-AI v1.0 (AI 구현이 REG governance 준수), SPEC-XPE-SEC (cybersecurity 세부), SPEC-XPE-OPS (post-market)
+- **External**: FDA pre-submission (Q-Sub) meeting, ISO 42001 certification body engagement
+
+---
+
+## 10. Change Control
+
+변경 사유:
+1. FDA guidance update (subscription monitoring required)
+2. EU AI Act 이행법 변경
+3. Audit finding
+4. Clinical validation outcome
+
+변경 승인:
+- Minor (editorial): Author
+- Major (정책): Legal counsel + Regulatory Affairs
+- Critical (제출 후): FDA pre-submission consult
+
+---
+
+**본 SPEC은 XPE 프로젝트의 최상위 규제 정박점이다. 모든 AI-DSF 개발은 본 문서의 REQ-REG-XXX를 만족해야 한다.**

--- a/.moai/specs/SPEC-XPE-SEC/spec.md
+++ b/.moai/specs/SPEC-XPE-SEC/spec.md
@@ -1,0 +1,336 @@
+# SPEC-XPE-SEC: Cybersecurity Master
+
+---
+id: SPEC-XPE-SEC
+version: 1.1.0
+status: Draft
+created: 2026-04-17
+updated: 2026-04-17
+author: MoAI (manager-spec orchestration)
+priority: Mixed (Must for M-04~M-07 core; Should for SLSA L3, IEC 81001-5-1, threat model 확장)
+issue_number: null
+iec62304_class: B
+development_mode: TDD
+sprint: S-SEC-CORE (Must) + S-SEC-EXT (Should)
+dependency: SPEC-XPE-MASTER v3.0.0, trend-survey-2026.md v1.1, S0-B
+---
+
+## Priority Reclassification Notice (v1.1)
+
+본 SPEC의 우선순위는 trend-survey-2026.md v1.1 엄격 재분류에 따라 혼합:
+
+- **Must (즉시 착수, §524B 법적 의무)**: FDA Section 524B cyber device 요건, SBOM (SPDX 3.0 + CycloneDX 1.6) 발급, Vulnerability Management, Basic Input Validation
+- **Should (권장, Phase별 조건부)**: SLSA L2→L3 upgrade, IEC 81001-5-1 SDLC 통합, STRIDE + MITRE EMB3D 고도화, CVD 공개 절차, 재현 가능 빌드
+- **현재 실행 범위**: Must 부분(§524B 필수)은 즉시, Should 부분은 Phase 2에 점진적 확장
+
+## HISTORY
+
+| Version | Date       | Author       | Changes                                   |
+|---------|------------|--------------|-------------------------------------------|
+| 1.0.0   | 2026-04-17 | MoAI         | Initial EARS SPEC integrating FDA §524B, SBOM (SPDX 3.0/CycloneDX 1.6), IEC 81001-5-1, SLSA L3, STRIDE+EMB3D, CVD |
+
+---
+
+## 1. Scope
+
+### 1.1 Overview
+
+본 SPEC은 XPE 프로젝트의 **사이버보안 마스터 문서**로서, FDA Section 524B 의무와 IEC 81001-5-1 Secure Software Lifecycle을 단일 통합 프레임워크로 정리한다. 본 문서는 IEC 62304 및 SPEC-XPE-REG에 **오버레이**로 기능한다.
+
+본 SPEC이 다루는 6개 보안 축:
+
+1. **FDA Section 524B** (Cyber Device premarket cybersecurity, 2023 법제화, 2025-06 final guidance)
+2. **SBOM** (SPDX 3.0 / CycloneDX 1.6, FDA NTIA 최소 요소)
+3. **IEC 81001-5-1** (Secure Software Lifecycle, 64 cybersecurity requirements)
+4. **SLSA Levels 1→3** (Build provenance and supply chain integrity)
+5. **Threat Modeling** (STRIDE + MITRE EMB3D + MDIC Playbook)
+6. **Coordinated Vulnerability Disclosure** (CVD, ISO/IEC 29147)
+
+### 1.2 In Scope
+
+- Secure Product Development Framework (SPDF) per §524B
+- SBOM generation, distribution, continuous VEX tracking
+- Threat model for each Layer 1 DLL + GUI + network boundaries
+- Vulnerability management and coordinated disclosure process
+- Build attestation (SLSA L3 with in-toto provenance)
+- Security testing (SAST/DAST/fuzzing/dependency scanning)
+- Incident response plan
+- Cryptographic controls (transport, at-rest, signature)
+- Security-related user documentation
+
+### 1.3 Exclusions
+
+- Regulatory governance: SPEC-XPE-REG
+- Interoperability (DICOM TLS specifics): SPEC-XPE-IOP
+- AI-specific security (model poisoning, adversarial): SPEC-XPE-P3-AI §8
+- Physical device security: out of scope (SW only)
+- Privacy/PHI beyond DICOM de-identification: out of scope
+
+---
+
+## 2. Referenced Documents
+
+| Document ID | Title | Version | Role |
+|-------------|-------|---------|------|
+| FDA-524B | FD&C Act Section 524B (Consolidated Appropriations Act 2023 §3305) | 2023 | Normative (law) |
+| FDA-CYBER-2025 | Cybersecurity in Medical Devices: QS Considerations and Premarket Submissions | Final 2025-06-27 | Normative |
+| IEC-81001-5-1 | Health software security lifecycle | 2021 + Interpretation Sheet 2025-12 | Normative |
+| SPDX-3.0 | Software Package Data Exchange | 3.0 (2024) | Normative (choice) |
+| CycloneDX-1.6 | OWASP CycloneDX | 1.6 (2024) | Normative (choice) |
+| SLSA-v1.1 | Supply Chain Levels for Software Artifacts | v1.1 | Normative |
+| NIST-SSDF | Secure Software Development Framework | SP 800-218 | Informative |
+| NIST-CSWP-27 | Recommended Minimum Standard for Vendor or Developer Verification | 2021 | Informative |
+| MITRE-EMB3D | Embedded Device Threat Model | 2024 enhanced with IEC 62443-4-2 | Informative |
+| MDIC-PTM | Playbook for Threat Modeling Medical Devices | 2021 | Informative |
+| ISO-IEC-29147 | Vulnerability disclosure | 2018 | Normative |
+| ISO-IEC-30111 | Vulnerability handling processes | 2019 | Normative |
+| OWASP-ASVS | Application Security Verification Standard | 4.0.3 | Informative |
+| SPEC-XPE-REG | Regulatory Master | v1.0.0 | Upstream |
+| SPEC-XPE-MASTER | XPE Master Implementation Plan | v3.0.0 | Upstream |
+
+---
+
+## 3. Definitions
+
+| Term | Definition |
+|------|-----------|
+| Cyber Device | §524B: SW-enabled + internet-capable medical device |
+| SPDF | Secure Product Development Framework |
+| SBOM | Software Bill of Materials |
+| VEX | Vulnerability Exploitability eXchange |
+| SLSA | Supply-chain Levels for Software Artifacts |
+| CVD | Coordinated Vulnerability Disclosure |
+| SAST | Static Application Security Testing |
+| DAST | Dynamic Application Security Testing |
+| STRIDE | Spoofing, Tampering, Repudiation, Information disclosure, Denial of service, Elevation of privilege |
+| EMB3D | MITRE Embedded Device Threat Model |
+| in-toto | Supply chain attestation framework |
+| CSAF | Common Security Advisory Framework |
+| SOUP | Software of Unknown Provenance (IEC 62304) |
+| CWE | Common Weakness Enumeration |
+| CAPEC | Common Attack Pattern Enumeration and Classification |
+
+---
+
+## 4. Requirements (EARS Format)
+
+### 4.1 Cyber Device Classification
+
+**REQ-SEC-001** (Ubiquitous): The XPE system shall determine its classification as Cyber Device per §524B based on: (1) inclusion of software, (2) ability to connect to internet, (3) presence of vulnerable technological characteristics.
+
+**REQ-SEC-002** (State-driven): If XPE is deployed in a networked environment with DICOM Network SCU/SCP, the system shall be classified as Cyber Device subject to §524B.
+
+### 4.2 Secure Product Development Framework (SPDF)
+
+**REQ-SEC-010** (Ubiquitous): The XPE project shall implement SPDF practices aligned with IEC 81001-5-1.
+
+**REQ-SEC-011** (Ubiquitous): Each software unit (SWU) shall undergo threat modeling per STRIDE and cross-reference with MITRE EMB3D.
+
+**REQ-SEC-012** (Ubiquitous): Security requirements shall be traced to design, implementation, and test artifacts.
+
+**REQ-SEC-013** (Event-driven): When a new SOUP is introduced, the system shall perform security risk assessment including known vulnerabilities, support lifecycle, and attack surface impact.
+
+**REQ-SEC-014** (Ubiquitous): Secure coding guidelines shall be enforced for C++ (CERT C++), C ABI boundary hardening, and C# (OWASP .NET).
+
+### 4.3 SBOM Requirements
+
+**REQ-SEC-020** (Ubiquitous): The XPE build shall generate a SBOM in both SPDX 3.0 AND CycloneDX 1.6 formats (machine-readable).
+
+**REQ-SEC-021** (Ubiquitous): The SBOM shall contain NTIA minimum elements: supplier name, component name, version string, unique identifiers, dependency relationships, author, timestamp.
+
+**REQ-SEC-022** (Ubiquitous): The SBOM shall list all commercial, open-source, and off-the-shelf software components integrated into the device.
+
+**REQ-SEC-023** (Ubiquitous): For each SOUP component, the SBOM shall include: CPE or PURL identifier, support end date, license identifier (SPDX).
+
+**REQ-SEC-024** (Event-driven): When any SOUP version changes, the SBOM shall be regenerated and a new version recorded.
+
+**REQ-SEC-025** (Ubiquitous): The SBOM shall be distributed with each release through machine-readable channel (public URL, API, or distribution package).
+
+**REQ-SEC-026** (Ubiquitous): SBOM versions shall be retained per device configuration for the expected support window (10+ years for medical devices).
+
+### 4.4 Vulnerability Management
+
+**REQ-SEC-030** (Ubiquitous): The XPE project shall monitor published vulnerabilities (NVD CVE, GitHub Advisory Database, OSV) for all SBOM components.
+
+**REQ-SEC-031** (Event-driven): When a vulnerability is published affecting an SBOM component, the system shall perform exploitability analysis within 48 hours.
+
+**REQ-SEC-032** (Event-driven): When exploitability analysis completes, a VEX document (CycloneDX VEX or OpenVEX or CSAF 2.0) shall be generated with status: affected, not_affected, fixed, or under_investigation.
+
+**REQ-SEC-033** (Ubiquitous): Critical CVEs (CVSS ≥ 9.0) shall have a mitigation plan within 7 days and patch within 60 days.
+
+**REQ-SEC-034** (Ubiquitous): The project shall publish a Security Advisory for each confirmed exploitable vulnerability per ISO/IEC 29147.
+
+### 4.5 Supply Chain Security (SLSA)
+
+**REQ-SEC-040** (Ubiquitous): Builds shall achieve SLSA Level 1 minimum: provenance exists describing how the package was built.
+
+**REQ-SEC-041** (Ubiquitous): Release builds shall achieve SLSA Level 2: provenance is digitally signed by the build platform.
+
+**REQ-SEC-042** (Ubiquitous): Release builds SHALL achieve SLSA Level 3 (Phase 2 target): build steps run in isolated environment; provenance is unforgeable.
+
+**REQ-SEC-043** (Ubiquitous): Builds shall generate in-toto attestations alongside artifacts.
+
+**REQ-SEC-044** (Ubiquitous): Release artifacts shall be reproducible: identical source + build environment produces bit-identical output (SOURCE_DATE_EPOCH for CMake/Ninja).
+
+### 4.6 Threat Model
+
+**REQ-SEC-050** (Ubiquitous): A STRIDE-based threat model shall be maintained for each trust boundary: (a) DICOM network SCU/SCP, (b) P/Invoke C ABI boundary, (c) File system I/O (config, images, logs), (d) C# GUI process boundary, (e) vcpkg SOUP consumption.
+
+**REQ-SEC-051** (Ubiquitous): Each identified threat shall be mapped to MITRE ATT&CK technique and MITRE EMB3D property.
+
+**REQ-SEC-052** (Ubiquitous): Each identified threat shall have tiered mitigation: foundational, intermediate, leading (per EMB3D 2024 enhancement).
+
+**REQ-SEC-053** (Ubiquitous): The threat model shall be reviewed at each major release (v1.0, v2.0, etc.) and when significant architecture changes occur.
+
+### 4.7 Secure Coding and Testing
+
+**REQ-SEC-060** (Ubiquitous): All C ABI boundary functions shall validate input buffer sizes before dereferencing.
+
+**REQ-SEC-061** (Ubiquitous): All C ABI boundary functions shall validate JSON config against schema before use.
+
+**REQ-SEC-062** (Ubiquitous): All DICOM parsing shall use DCMTK with strict mode enabled and fuzz-tested against malformed inputs.
+
+**REQ-SEC-063** (Ubiquitous): Static analysis shall run in CI with rules from CERT C++, MISRA C++:2008 (subset), and CWE Top 25.
+
+**REQ-SEC-064** (Ubiquitous): Fuzz testing shall run against: (a) DICOM parser, (b) JSON config parser, (c) image header validators.
+
+**REQ-SEC-065** (Ubiquitous): Dependency scanning (OSV-Scanner, Grype) shall run on every CI build.
+
+**REQ-SEC-066** (Ubiquitous): Secrets scanning (gitleaks, trufflehog) shall run on every commit.
+
+### 4.8 Cryptographic Controls
+
+**REQ-SEC-070** (Ubiquitous): DICOM Network transport shall support TLS 1.2+ with recommended cipher suites per NIST SP 800-52 Rev. 2.
+
+**REQ-SEC-071** (Ubiquitous): Audit logs shall be hash-chained (SHA-256) to provide tamper evidence.
+
+**REQ-SEC-072** (Ubiquitous): Configuration files may be digitally signed (Ed25519 or ECDSA P-256) when tamper detection is required.
+
+**REQ-SEC-073** (Ubiquitous): Release binaries shall be signed (Authenticode for Windows).
+
+### 4.9 Incident Response
+
+**REQ-SEC-080** (Event-driven): When a security incident is detected or reported, an incident response workflow per ISO/IEC 30111 shall activate.
+
+**REQ-SEC-081** (Ubiquitous): Incident response shall include: acknowledgment (within 72 hours per FDA §524B), triage, containment, eradication, recovery, lessons learned.
+
+**REQ-SEC-082** (Ubiquitous): Customer notification for confirmed exploitable vulnerabilities shall follow FDA §524B and EU MDR Article 83.
+
+### 4.10 Coordinated Vulnerability Disclosure
+
+**REQ-SEC-090** (Ubiquitous): The project shall maintain a public SECURITY.md with disclosure policy, contact email, PGP key, and response SLA.
+
+**REQ-SEC-091** (Ubiquitous): A vulnerability disclosure tracking system shall be maintained (private issue tracker).
+
+**REQ-SEC-092** (Ubiquitous): Disclosure shall follow coordinated timeline: 90-day default, extendable by mutual agreement, per ISO/IEC 29147.
+
+---
+
+## 5. Acceptance Criteria
+
+### 5.1 SBOM Artifacts
+
+- [ ] `sbom/xpe-{version}.spdx.json` generated per release
+- [ ] `sbom/xpe-{version}.cdx.json` generated per release
+- [ ] SBOM includes all 8 XPE DLLs + GSVG + vcpkg SOUP
+- [ ] SBOM published at `https://github.com/holee9/image-processing/releases/download/{version}/sbom-xpe-{version}.*`
+
+### 5.2 Provenance & Attestation
+
+- [ ] SLSA L2 attestation present on every release
+- [ ] SLSA L3 attestation present on every release from v2.0+
+- [ ] Reproducible build verified (bit-identical hash across 2+ runs)
+
+### 5.3 Vulnerability & Scanning
+
+- [ ] OSV-Scanner reports 0 critical unresolved
+- [ ] Grype reports 0 critical unresolved (or VEX-justified)
+- [ ] gitleaks reports 0 secrets on main branch
+- [ ] CodeQL/SonarQube static analysis passes with 0 criticals
+
+### 5.4 Threat Model
+
+- [ ] 5 trust boundary threat models documented
+- [ ] ATT&CK + EMB3D mapping for each threat
+- [ ] Tiered mitigations specified
+
+### 5.5 Process
+
+- [ ] SECURITY.md published
+- [ ] VDP contact verified
+- [ ] Incident response runbook tested with tabletop exercise
+- [ ] IEC 81001-5-1 audit checklist green
+
+---
+
+## 6. Out-of-Scope Clarifications
+
+- Privacy (HIPAA, GDPR) beyond DICOM de-identification → hospital IT domain
+- Physical tamper resistance → hardware team
+- Network-level security (firewall rules) → hospital IT
+- Federated learning security → SPEC-XPE-P3-AI §8 (separate)
+
+---
+
+## 7. Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|:--------:|-----------|
+| FFTW3 GPL license contamination (GSVG) | Medium | Dynamic link only, GSVG as separate DLL, documented in SBOM |
+| OpenSSL (DCMTK transitive) export restrictions | Medium | Per-jurisdiction legal review, documented in tech.md |
+| SLSA L3 infra not available | High | Use GitHub Actions hosted runners with SLSA generator reusable workflow |
+| SOUP with no active maintenance | High | Replace or fork + support internally; mark in SBOM |
+| Adversarial model attacks (AI modules) | Medium | Defer to SPEC-XPE-P3-AI §8 (specialized) |
+| Zero-day in C++ runtime | High | Rapid patch SLA (60d critical), coordinate with Microsoft |
+| Shadow IT P/Invoke misuse | Low | Sign ImageProcTest.exe with Authenticode, enforce loader |
+
+---
+
+## 8. Deliverables
+
+### 8.1 Documents (11)
+
+1. `docs/security/spdf-plan.md` — Secure Product Development Framework
+2. `docs/security/threat-model-dicom.md`
+3. `docs/security/threat-model-cabi.md`
+4. `docs/security/threat-model-fsio.md`
+5. `docs/security/threat-model-gui.md`
+6. `docs/security/threat-model-soup.md`
+7. `docs/security/vulnerability-management-plan.md`
+8. `docs/security/incident-response-plan.md`
+9. `docs/security/cryptographic-controls.md`
+10. `SECURITY.md` — Public disclosure policy
+11. `docs/security/iec-81001-5-1-compliance-matrix.md`
+
+### 8.2 Automation/Code Artifacts
+
+- `.github/workflows/sbom.yml` — SPDX + CycloneDX generation
+- `.github/workflows/slsa.yml` — SLSA L2→L3 attestation
+- `.github/workflows/scan.yml` — OSV-Scanner + Grype + gitleaks + CodeQL
+- `scripts/gen_sbom.sh` — Local SBOM generation
+- `scripts/verify_reproducible.sh` — Reproducibility check
+- Header: `modules/common/include/xpe/common/xpe_secure.h` (crypto helpers)
+
+### 8.3 RTM Entries
+
+- 40+ REQ-SEC-XXX entries mapped to security controls
+
+---
+
+## 9. Dependencies
+
+- **Upstream**: SPEC-XPE-MASTER v3.0.0, SPEC-XPE-REG v1.0, S0-B (xpe_common) completion
+- **Downstream**: All Layer 1 DLL implementations (P1A, P1B*, P2, P3), SPEC-XPE-P3-AI §8
+- **External**: GitHub Actions (CI), SLSA generator, OSV.dev
+
+---
+
+## 10. Change Control
+
+- Security policy changes require Security Lead approval
+- New threats discovered: add to threat model within 7 days
+- CVE published affecting XPE: immediate incident response
+
+---
+
+**본 SPEC은 XPE 프로젝트의 사이버보안 마스터로서 FDA §524B 법적 의무와 IEC 81001-5-1 표준을 구현한다.**

--- a/clients/ImageProcTest/App.xaml
+++ b/clients/ImageProcTest/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:ImageProcTest"
-             StartupUri="MainWindow.xaml">
+             Startup="Application_Startup">
     <Application.Resources>
     </Application.Resources>
 </Application>

--- a/clients/ImageProcTest/App.xaml.cs
+++ b/clients/ImageProcTest/App.xaml.cs
@@ -4,5 +4,37 @@ namespace ImageProcTest
 {
     public partial class App : Application
     {
+        private void Application_Startup(object sender, StartupEventArgs e)
+        {
+            if (e.Args.Contains("--probe-native-readiness", StringComparer.OrdinalIgnoreCase))
+            {
+                RunNativeReadinessProbe();
+                return;
+            }
+
+            var window = new MainWindow();
+            MainWindow = window;
+            window.Show();
+        }
+
+        private void RunNativeReadinessProbe()
+        {
+            IXpeBackend backend = new CompositeXpeBackend(new RealXpeCommonBackend(), new MockXpeBackend());
+            try
+            {
+                var health = backend.CheckHealth();
+                var report = NativeReadinessProbe.WriteReport(health);
+                var exitCode = report.PreprocessHealth.IsSyntheticOracleReady ? 0 : 2;
+                Shutdown(exitCode);
+            }
+            catch
+            {
+                Shutdown(1);
+            }
+            finally
+            {
+                backend.Shutdown();
+            }
+        }
     }
 }

--- a/clients/ImageProcTest/Diagnostics/NativeReadinessProbe.cs
+++ b/clients/ImageProcTest/Diagnostics/NativeReadinessProbe.cs
@@ -8,7 +8,8 @@ namespace ImageProcTest
     internal sealed record NativeReadinessReportWriteResult(
         string ReportPath,
         string DisplaySummary,
-        string PreprocessSummary);
+        string PreprocessSummary,
+        PreprocessHealthResult PreprocessHealth);
 
     internal sealed record DisplayHealthResult(
         string Status,
@@ -25,8 +26,53 @@ namespace ImageProcTest
         IReadOnlyList<string> PresentExports,
         IReadOnlyList<string> MissingExports,
         IReadOnlyList<string> MissingExecutionExports,
+        PreprocessSyntheticOracleResult SyntheticOracle,
         bool IsVersionReady,
-        bool IsExportReady);
+        bool IsExportReady,
+        bool IsSyntheticOracleReady);
+
+    internal sealed record PreprocessSyntheticStageResult(
+        string Stage,
+        string ErrorCode,
+        double LatencyMs,
+        double MaxAbsError,
+        bool Passed);
+
+    internal sealed record PreprocessSyntheticOracleResult(
+        string Status,
+        string Details,
+        bool Executed,
+        bool Passed,
+        double TotalLatencyMs,
+        bool InputPreserved,
+        string RawSha256Before,
+        string RawSha256After,
+        string OutputSha256,
+        int NaNInfCount,
+        double DeterminismRmse,
+        double OutputMin,
+        double OutputMax,
+        IReadOnlyList<PreprocessSyntheticStageResult> Stages)
+    {
+        public static PreprocessSyntheticOracleResult NotRun(string details)
+        {
+            return new PreprocessSyntheticOracleResult(
+                Status: "Not run",
+                Details: details,
+                Executed: false,
+                Passed: false,
+                TotalLatencyMs: 0,
+                InputPreserved: false,
+                RawSha256Before: "",
+                RawSha256After: "",
+                OutputSha256: "",
+                NaNInfCount: 0,
+                DeterminismRmse: double.NaN,
+                OutputMin: double.NaN,
+                OutputMax: double.NaN,
+                Stages: []);
+        }
+    }
 
     internal static class NativeReadinessProbe
     {
@@ -55,7 +101,8 @@ namespace ImageProcTest
             return new NativeReadinessReportWriteResult(
                 path,
                 $"{display.Status} ({display.Version})",
-                $"{preprocess.Status} ({preprocess.Version})");
+                $"{preprocess.Status} ({preprocess.Version}); smoke={preprocess.SyntheticOracle.Status}",
+                preprocess);
         }
     }
 }

--- a/clients/ImageProcTest/Diagnostics/XpePreprocessReadinessProbe.cs
+++ b/clients/ImageProcTest/Diagnostics/XpePreprocessReadinessProbe.cs
@@ -72,20 +72,27 @@ namespace ImageProcTest
                             PresentExports: present,
                             MissingExports: missing,
                             MissingExecutionExports: missingExecution,
+                            SyntheticOracle: PreprocessSyntheticOracleResult.NotRun("Export checklist is incomplete."),
                             IsVersionReady: version != "Unavailable",
-                            IsExportReady: false);
+                            IsExportReady: false,
+                            IsSyntheticOracleReady: false);
                     }
 
+                    var synthetic = XpePreprocessSyntheticOracle.Run(candidate);
                     return new PreprocessHealthResult(
-                        Status: "Export checklist ready",
+                        Status: synthetic.Passed ? "Synthetic oracle ready" : "Export checklist ready",
                         Version: version,
                         DllPath: candidate,
-                        Details: "Preprocess exports are discoverable. Native image execution remains gated until ABI smoke, synthetic oracle, and fixture E2E pass.",
+                        Details: synthetic.Passed
+                            ? "Preprocess exports are discoverable and the 16x16 synthetic adapter-chain oracle passed. Real fixture execution remains gated until R4 fixture E2E passes."
+                            : "Preprocess exports are discoverable. Native real-image execution remains gated until ABI smoke, synthetic oracle, and fixture E2E pass.",
                         PresentExports: present,
                         MissingExports: missing,
                         MissingExecutionExports: missingExecution,
+                        SyntheticOracle: synthetic,
                         IsVersionReady: true,
-                        IsExportReady: true);
+                        IsExportReady: true,
+                        IsSyntheticOracleReady: synthetic.Passed);
                 }
                 finally
                 {
@@ -101,8 +108,10 @@ namespace ImageProcTest
                 PresentExports: [],
                 MissingExports: RequiredExports,
                 MissingExecutionExports: ExecutionExports,
+                SyntheticOracle: PreprocessSyntheticOracleResult.NotRun("DLL not found."),
                 IsVersionReady: false,
-                IsExportReady: false);
+                IsExportReady: false,
+                IsSyntheticOracleReady: false);
         }
 
         private static IEnumerable<string> GetDllCandidates()

--- a/clients/ImageProcTest/Diagnostics/XpePreprocessSyntheticOracle.cs
+++ b/clients/ImageProcTest/Diagnostics/XpePreprocessSyntheticOracle.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace ImageProcTest
+{
+    internal static class XpePreprocessSyntheticOracle
+    {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate XpeCommonApi.XpeErrorCode InitDelegate(IntPtr config);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void ShutdownDelegate();
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate XpeCommonApi.XpeErrorCode CorrectionDelegate(
+            ref XpeCommonApi.XpeImageBuffer input,
+            ref XpeCommonApi.XpeImageBuffer output,
+            ref XpeCommonApi.XpeImageMetadata metadata);
+
+        public static PreprocessSyntheticOracleResult Run(string dllPath)
+        {
+            if (!File.Exists(dllPath))
+            {
+                return PreprocessSyntheticOracleResult.NotRun($"DLL not found: {dllPath}");
+            }
+
+            if (!NativeLibrary.TryLoad(dllPath, out var handle))
+            {
+                return PreprocessSyntheticOracleResult.NotRun($"DLL load failed: {dllPath}");
+            }
+
+            try
+            {
+                if (!TryGetDelegate(handle, "xpe_preprocess_init", out InitDelegate? init) ||
+                    !TryGetDelegate(handle, "xpe_preprocess_shutdown", out ShutdownDelegate? shutdown) ||
+                    !TryGetDelegate(handle, "xpe_offset_correct", out CorrectionDelegate? offsetCorrect) ||
+                    !TryGetDelegate(handle, "xpe_gain_correct", out CorrectionDelegate? gainCorrect) ||
+                    !TryGetDelegate(handle, "xpe_defect_correct", out CorrectionDelegate? defectCorrect))
+                {
+                    return PreprocessSyntheticOracleResult.NotRun("Mandatory correction exports are not available.");
+                }
+
+                var initFn = init ?? throw new InvalidOperationException("xpe_preprocess_init delegate is null.");
+                var shutdownFn = shutdown ?? throw new InvalidOperationException("xpe_preprocess_shutdown delegate is null.");
+                var offsetFn = offsetCorrect ?? throw new InvalidOperationException("xpe_offset_correct delegate is null.");
+                var gainFn = gainCorrect ?? throw new InvalidOperationException("xpe_gain_correct delegate is null.");
+                var defectFn = defectCorrect ?? throw new InvalidOperationException("xpe_defect_correct delegate is null.");
+
+                shutdownFn();
+                var initResult = initFn(IntPtr.Zero);
+                if (initResult != XpeCommonApi.XpeErrorCode.OK)
+                {
+                    return new PreprocessSyntheticOracleResult(
+                        Status: "Init failed",
+                        Details: $"xpe_preprocess_init(NULL) returned {initResult}.",
+                        Executed: true,
+                        Passed: false,
+                        TotalLatencyMs: 0,
+                        InputPreserved: false,
+                        RawSha256Before: "",
+                        RawSha256After: "",
+                        OutputSha256: "",
+                        NaNInfCount: 0,
+                        DeterminismRmse: double.NaN,
+                        OutputMin: double.NaN,
+                        OutputMax: double.NaN,
+                        Stages: []);
+                }
+
+                try
+                {
+                    var first = RunChain(offsetFn, gainFn, defectFn);
+                    var second = RunChain(offsetFn, gainFn, defectFn);
+                    var determinismRmse = CalculateRmse(first.Output, second.Output);
+                    var outputSha = ComputeSha256(first.Output);
+                    var passed = first.Passed && second.Passed && determinismRmse == 0;
+
+                    return new PreprocessSyntheticOracleResult(
+                        Status: passed ? "Synthetic oracle pass" : "Synthetic oracle fail",
+                        Details: passed
+                            ? "16x16 synthetic offset->gain->defect adapter chain passed with identity/no-calibration semantics."
+                            : "Synthetic adapter chain executed but one or more gates failed.",
+                        Executed: true,
+                        Passed: passed,
+                        TotalLatencyMs: first.TotalLatencyMs + second.TotalLatencyMs,
+                        InputPreserved: first.InputPreserved && second.InputPreserved,
+                        RawSha256Before: first.RawSha256Before,
+                        RawSha256After: first.RawSha256After,
+                        OutputSha256: outputSha,
+                        NaNInfCount: first.NaNInfCount + second.NaNInfCount,
+                        DeterminismRmse: determinismRmse,
+                        OutputMin: first.OutputMin,
+                        OutputMax: first.OutputMax,
+                        Stages: first.Stages);
+                }
+                finally
+                {
+                    shutdownFn();
+                }
+            }
+            catch (Exception ex)
+            {
+                return new PreprocessSyntheticOracleResult(
+                    Status: "Synthetic oracle exception",
+                    Details: ex.Message,
+                    Executed: true,
+                    Passed: false,
+                    TotalLatencyMs: 0,
+                    InputPreserved: false,
+                    RawSha256Before: "",
+                    RawSha256After: "",
+                    OutputSha256: "",
+                    NaNInfCount: 0,
+                    DeterminismRmse: double.NaN,
+                    OutputMin: double.NaN,
+                    OutputMax: double.NaN,
+                    Stages: []);
+            }
+            finally
+            {
+                NativeLibrary.Free(handle);
+            }
+        }
+
+        private static bool TryGetDelegate<TDelegate>(IntPtr handle, string exportName, out TDelegate? value)
+            where TDelegate : Delegate
+        {
+            if (!NativeLibrary.TryGetExport(handle, exportName, out var symbol))
+            {
+                value = null;
+                return false;
+            }
+
+            value = Marshal.GetDelegateForFunctionPointer<TDelegate>(symbol);
+            return true;
+        }
+
+        private static ChainRunResult RunChain(
+            CorrectionDelegate offsetCorrect,
+            CorrectionDelegate gainCorrect,
+            CorrectionDelegate defectCorrect)
+        {
+            const uint width = 16;
+            const uint height = 16;
+            const int pixelCount = (int)(width * height);
+
+            var raw = Enumerable.Range(0, pixelCount)
+                .Select(index => (ushort)(1000 + (index % 97)))
+                .ToArray();
+            var offset = new ushort[pixelCount];
+            var gain = new float[pixelCount];
+            var defect = new float[pixelCount];
+
+            var rawShaBefore = ComputeSha256(raw);
+            var stages = new List<PreprocessSyntheticStageResult>();
+            var total = Stopwatch.StartNew();
+
+            var rawHandle = GCHandle.Alloc(raw, GCHandleType.Pinned);
+            var offsetHandle = GCHandle.Alloc(offset, GCHandleType.Pinned);
+            var gainHandle = GCHandle.Alloc(gain, GCHandleType.Pinned);
+            var defectHandle = GCHandle.Alloc(defect, GCHandleType.Pinned);
+
+            try
+            {
+                var metadata = CreateMetadata();
+                var rawBuffer = CreateBuffer(width, height, XpeCommonApi.XpePixelFormat.UInt16, rawHandle.AddrOfPinnedObject(), raw.Length * sizeof(ushort));
+                var offsetBuffer = CreateBuffer(width, height, XpeCommonApi.XpePixelFormat.UInt16, offsetHandle.AddrOfPinnedObject(), offset.Length * sizeof(ushort));
+                var gainBuffer = CreateBuffer(width, height, XpeCommonApi.XpePixelFormat.Float32, gainHandle.AddrOfPinnedObject(), gain.Length * sizeof(float));
+                var defectBuffer = CreateBuffer(width, height, XpeCommonApi.XpePixelFormat.Float32, defectHandle.AddrOfPinnedObject(), defect.Length * sizeof(float));
+
+                var offsetResult = TimedCall("offset", () => offsetCorrect(ref rawBuffer, ref offsetBuffer, ref metadata));
+                stages.Add(offsetResult.ToStageResult(MaxAbsError(offset, raw), offsetResult.ErrorCode == XpeCommonApi.XpeErrorCode.OK && MaxAbsError(offset, raw) == 0));
+
+                var gainResult = TimedCall("gain", () => gainCorrect(ref offsetBuffer, ref gainBuffer, ref metadata));
+                stages.Add(gainResult.ToStageResult(MaxAbsError(gain, offset), gainResult.ErrorCode == XpeCommonApi.XpeErrorCode.OK && MaxAbsError(gain, offset) == 0));
+
+                var defectResult = TimedCall("defect", () => defectCorrect(ref gainBuffer, ref defectBuffer, ref metadata));
+                stages.Add(defectResult.ToStageResult(MaxAbsError(defect, gain), defectResult.ErrorCode == XpeCommonApi.XpeErrorCode.OK && MaxAbsError(defect, gain) == 0));
+            }
+            finally
+            {
+                rawHandle.Free();
+                offsetHandle.Free();
+                gainHandle.Free();
+                defectHandle.Free();
+                total.Stop();
+            }
+
+            var rawShaAfter = ComputeSha256(raw);
+            var nanInfCount = defect.Count(value => float.IsNaN(value) || float.IsInfinity(value));
+            var inputPreserved = string.Equals(rawShaBefore, rawShaAfter, StringComparison.OrdinalIgnoreCase);
+            var passed = inputPreserved && nanInfCount == 0 && stages.All(stage => stage.Passed);
+
+            return new ChainRunResult(
+                Passed: passed,
+                TotalLatencyMs: total.Elapsed.TotalMilliseconds,
+                InputPreserved: inputPreserved,
+                RawSha256Before: rawShaBefore,
+                RawSha256After: rawShaAfter,
+                NaNInfCount: nanInfCount,
+                OutputMin: defect.Min(),
+                OutputMax: defect.Max(),
+                Output: defect,
+                Stages: stages);
+        }
+
+        private static XpeCommonApi.XpeImageBuffer CreateBuffer(
+            uint width,
+            uint height,
+            XpeCommonApi.XpePixelFormat format,
+            IntPtr data,
+            int dataSize)
+        {
+            return new XpeCommonApi.XpeImageBuffer
+            {
+                Width = width,
+                Height = height,
+                BitsAllocated = format == XpeCommonApi.XpePixelFormat.UInt16 ? 16u : 32u,
+                BitsStored = format == XpeCommonApi.XpePixelFormat.UInt16 ? 16u : 32u,
+                Format = format,
+                Data = data,
+                DataSize = (nuint)dataSize
+            };
+        }
+
+        private static XpeCommonApi.XpeImageMetadata CreateMetadata()
+        {
+            return new XpeCommonApi.XpeImageMetadata
+            {
+                BodyPart = "CHEST",
+                KVp = 120.0f,
+                MAs = 10.0f,
+                SID_mm = 1200.0f,
+                PixelPitch_mm = 0.143f,
+                AcquisitionTime = 0,
+                Flags = 0
+            };
+        }
+
+        private static TimedCallResult TimedCall(string stage, Func<XpeCommonApi.XpeErrorCode> call)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var errorCode = call();
+            stopwatch.Stop();
+            return new TimedCallResult(stage, errorCode, stopwatch.Elapsed.TotalMilliseconds);
+        }
+
+        private static double MaxAbsError(ushort[] actual, ushort[] expected)
+        {
+            var max = 0.0;
+            for (var i = 0; i < actual.Length; i++)
+            {
+                max = Math.Max(max, Math.Abs(actual[i] - expected[i]));
+            }
+
+            return max;
+        }
+
+        private static double MaxAbsError(float[] actual, ushort[] expected)
+        {
+            var max = 0.0;
+            for (var i = 0; i < actual.Length; i++)
+            {
+                max = Math.Max(max, Math.Abs(actual[i] - expected[i]));
+            }
+
+            return max;
+        }
+
+        private static double MaxAbsError(float[] actual, float[] expected)
+        {
+            var max = 0.0;
+            for (var i = 0; i < actual.Length; i++)
+            {
+                max = Math.Max(max, Math.Abs(actual[i] - expected[i]));
+            }
+
+            return max;
+        }
+
+        private static double CalculateRmse(float[] first, float[] second)
+        {
+            var sum = 0.0;
+            for (var i = 0; i < first.Length; i++)
+            {
+                var diff = first[i] - second[i];
+                sum += diff * diff;
+            }
+
+            return Math.Sqrt(sum / first.Length);
+        }
+
+        private static string ComputeSha256<T>(T[] values)
+            where T : struct
+        {
+            var bytes = MemoryMarshal.AsBytes(values.AsSpan());
+            return Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+        }
+
+        private sealed record TimedCallResult(
+            string Stage,
+            XpeCommonApi.XpeErrorCode ErrorCode,
+            double LatencyMs)
+        {
+            public PreprocessSyntheticStageResult ToStageResult(double maxAbsError, bool passed)
+            {
+                return new PreprocessSyntheticStageResult(Stage, ErrorCode.ToString(), LatencyMs, maxAbsError, passed);
+            }
+        }
+
+        private sealed record ChainRunResult(
+            bool Passed,
+            double TotalLatencyMs,
+            bool InputPreserved,
+            string RawSha256Before,
+            string RawSha256After,
+            int NaNInfCount,
+            double OutputMin,
+            double OutputMax,
+            float[] Output,
+            IReadOnlyList<PreprocessSyntheticStageResult> Stages);
+    }
+}

--- a/clients/ImageProcTest/MainWindow.xaml
+++ b/clients/ImageProcTest/MainWindow.xaml
@@ -41,6 +41,7 @@
                         <TextBlock x:Name="AlertText" Text="Alerts: Not checked" FontSize="13" Margin="0,0,0,5"/>
                         <TextBlock x:Name="DisplayHealthText" Text="Display health: Not checked" FontSize="13" Margin="0,0,0,5"/>
                         <TextBlock x:Name="PreprocessHealthText" Text="Preprocess health: Not checked" FontSize="13" Margin="0,0,0,5"/>
+                        <TextBlock x:Name="PreprocessSmokeText" Text="Preprocess smoke: Not checked" FontSize="13" Margin="0,0,0,5"/>
                         <TextBlock x:Name="ReportText" Text="Readiness report: Not generated" FontSize="13" Margin="0,0,0,5"/>
                         <TextBlock x:Name="DetailsText" Text="Details: Waiting for health check." FontSize="12" TextWrapping="Wrap"/>
                     </StackPanel>

--- a/clients/ImageProcTest/MainWindow.xaml.cs
+++ b/clients/ImageProcTest/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ namespace ImageProcTest
         private RawPreviewResult? currentPreview;
         private BackendHealthResult? lastBackendHealth;
         private string? lastReadinessReportPath;
+        private PreprocessHealthResult? lastPreprocessHealth;
         private IReadOnlyList<ModuleReadinessSnapshot> currentModuleReadiness = [];
 
         public MainWindow()
@@ -139,6 +140,7 @@ namespace ImageProcTest
                     currentPreview,
                     lastBackendHealth,
                     lastReadinessReportPath,
+                    lastPreprocessHealth,
                     GetStageModes(),
                     currentModuleReadiness);
 
@@ -171,16 +173,23 @@ namespace ImageProcTest
             {
                 var report = NativeReadinessProbe.WriteReport(result);
                 lastReadinessReportPath = report.ReportPath;
+                lastPreprocessHealth = report.PreprocessHealth;
                 DisplayHealthText.Text = $"Display health: {report.DisplaySummary}";
                 PreprocessHealthText.Text = $"Preprocess health: {report.PreprocessSummary}";
+                PreprocessSmokeText.Text =
+                    $"Preprocess smoke: {report.PreprocessHealth.SyntheticOracle.Status}; " +
+                    $"pass={report.PreprocessHealth.SyntheticOracle.Passed}; " +
+                    $"latency={report.PreprocessHealth.SyntheticOracle.TotalLatencyMs:0.###}ms";
                 ReportText.Text = $"Readiness report: {report.ReportPath}";
             }
             catch (Exception ex)
             {
                 DisplayHealthText.Text = "Display health: Report generation skipped";
                 PreprocessHealthText.Text = "Preprocess health: Report generation skipped";
+                PreprocessSmokeText.Text = "Preprocess smoke: Report generation skipped";
                 ReportText.Text = $"Readiness report: failed ({ex.Message})";
                 lastReadinessReportPath = null;
+                lastPreprocessHealth = null;
             }
 
             RefreshModuleReadiness();

--- a/clients/ImageProcTest/Services/GuiE2eReportService.cs
+++ b/clients/ImageProcTest/Services/GuiE2eReportService.cs
@@ -19,6 +19,7 @@ namespace ImageProcTest
             RawPreviewResult? preview,
             BackendHealthResult? backendHealth,
             string? readinessReportPath,
+            PreprocessHealthResult? preprocessHealth,
             IReadOnlyList<StageModeSnapshot> stageModes,
             IReadOnlyList<ModuleReadinessSnapshot> moduleReadiness)
         {
@@ -61,6 +62,8 @@ namespace ImageProcTest
                 },
                 backendHealth,
                 readinessReportPath,
+                preprocessHealth,
+                preprocessSyntheticOracle = preprocessHealth?.SyntheticOracle,
                 moduleReadiness,
                 stageModes,
                 beforeAfter = new
@@ -79,7 +82,7 @@ namespace ImageProcTest
             var markdownPath = Path.Combine(directory, $"{name}.md");
 
             File.WriteAllText(jsonPath, JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
-            File.WriteAllText(markdownPath, RenderMarkdown(selectedCase, selectedRaw, preview, backendHealth, readinessReportPath, stageModes, moduleReadiness, timestamp));
+            File.WriteAllText(markdownPath, RenderMarkdown(selectedCase, selectedRaw, preview, backendHealth, readinessReportPath, preprocessHealth, stageModes, moduleReadiness, timestamp));
 
             return new GuiE2eReportWriteResult(jsonPath, markdownPath);
         }
@@ -90,6 +93,7 @@ namespace ImageProcTest
             RawPreviewResult? preview,
             BackendHealthResult? backendHealth,
             string? readinessReportPath,
+            PreprocessHealthResult? preprocessHealth,
             IReadOnlyList<StageModeSnapshot> stageModes,
             IReadOnlyList<ModuleReadinessSnapshot> moduleReadiness,
             DateTimeOffset timestamp)
@@ -103,6 +107,26 @@ namespace ImageProcTest
             builder.AppendLine($"- Readiness report: `{readinessReportPath ?? "none"}`");
             builder.AppendLine($"- Backend mode: `{backendHealth?.Mode ?? "unknown"}`");
             builder.AppendLine($"- Native processing enabled: `false`");
+            builder.AppendLine();
+
+            builder.AppendLine("## Preprocess Native Gate");
+            if (preprocessHealth is null)
+            {
+                builder.AppendLine("- Preprocess health was not checked.");
+            }
+            else
+            {
+                builder.AppendLine($"- Status: `{preprocessHealth.Status}`");
+                builder.AppendLine($"- Version: `{preprocessHealth.Version}`");
+                builder.AppendLine($"- DLL: `{preprocessHealth.DllPath}`");
+                builder.AppendLine($"- Synthetic oracle: `{preprocessHealth.SyntheticOracle.Status}`");
+                builder.AppendLine($"- Synthetic passed: `{preprocessHealth.SyntheticOracle.Passed}`");
+                builder.AppendLine($"- Total latency ms: `{preprocessHealth.SyntheticOracle.TotalLatencyMs:0.###}`");
+                builder.AppendLine($"- Input preserved: `{preprocessHealth.SyntheticOracle.InputPreserved}`");
+                builder.AppendLine($"- NaN/Inf count: `{preprocessHealth.SyntheticOracle.NaNInfCount}`");
+                builder.AppendLine($"- Determinism RMSE: `{preprocessHealth.SyntheticOracle.DeterminismRmse}`");
+            }
+
             builder.AppendLine();
 
             builder.AppendLine("## Raw Preview");

--- a/clients/ImageProcTest/Services/ModuleReadinessService.cs
+++ b/clients/ImageProcTest/Services/ModuleReadinessService.cs
@@ -80,12 +80,23 @@ namespace ImageProcTest
                     ? "pipeline export present"
                     : $"missing execution export(s): {string.Join(", ", health.MissingExecutionExports)}";
 
+                if (health.IsSyntheticOracleReady)
+                {
+                    return new ModuleReadinessSnapshot(
+                        "xpe_preprocess",
+                        "R3",
+                        "Synthetic oracle ready",
+                        $"version={health.Version}; dll={health.DllPath}; adapter-chain smoke passed; latency={health.SyntheticOracle.TotalLatencyMs:0.###}ms; {executionGap}",
+                        "Next: run local raw/calibration fixture E2E before enabling GUI On/Auto real processing.",
+                        ProcessingEnabled: false);
+                }
+
                 return new ModuleReadinessSnapshot(
                     "xpe_preprocess",
                     "R2",
                     "Version and export checklist ready",
-                    $"version={health.Version}; dll={health.DllPath}; {executionGap}",
-                    "Next: run ABI smoke, synthetic oracle, and fixture E2E before enabling GUI execution.",
+                    $"version={health.Version}; dll={health.DllPath}; synthetic={health.SyntheticOracle.Status}; {executionGap}",
+                    "Next: fix synthetic oracle gaps, then run fixture E2E before enabling GUI execution.",
                     ProcessingEnabled: false);
             }
 


### PR DESCRIPTION
## Summary
- **Must 27 → 12** 엄격 재분류 적용: 법률 의무 + 시장 진입 블로커 + IEC 62304 강제 조항만 Must
- 2024-2026 규제·보안·상호운용성·AI 트렌드 (28회 웹 서베이 교차검증) 통합
- 신규 SPEC 5종 추가 (REG/SEC/IOP/OPS/P3-AI v1.1) + MASTER v3 addendum

## 주요 변경

### v1.1 엄격 재분류
사용자 요구 **"반드시 필수일때만 must로 분류"** 반영. v1.0 Must 27 → v1.1 Must **12**로 축소.

| Tier | v1.0 | v1.1 | 변화 |
|------|:----:|:----:|:----:|
| Must | 27 | **12** | **-15 (조건부 승격 규칙 보유)** |
| Should | 19 | **35** | +16 (강등분 흡수) |
| Could | 10 | 10 | 0 |

### Must 12 항목 (진짜 블로커만)
- **Regulatory (3)**: IEC 62304 Class B, EU MDR 2017/745, FDA 21 CFR 820.30 + QMSR 2026
- **Cybersecurity (4)**: FDA §524B Cyber Device, SBOM, Vulnerability Management, Basic Input Validation
- **Interoperability (2)**: DICOM 3.0 Core, DICOM Conformance Statement
- **Operations (1)**: Post-Market Surveillance (EU MDR Article 83)
- **Quality/Architecture (2)**: Characterization Tests (IEC 62304 §5.4.1), Trackability (IEC 62304 §5.4.1)

### 조건부 Must 승격 규칙 (v1.1 신규)
- Phase 3 AI-DSF 배포 승인 → FDA PCCP, GMLP, AI-DSF Lifecycle, Transparency
- EU 시장 + AI 판매 결정 → EU AI Act High-Risk
- Connectathon 참여 결정 → IHE RAD Baseline
- SLSA L3 인증 결정 → SLSA L3 항목

### 점수 경로 재설정
- **Milestone 1 (Must 12만)**: Framework A **76점** (출시 블로커 해소, 법적 최소 상태)
- **Milestone 1-Ext (Must + 주요 Should)**: **85점** (기존 목표)
- **Milestone 2 (+ 전체 Should)**: **95점**
- **Milestone 3 (+ 선별 Could)**: **98점**

## 신규 SPEC 5종

| SPEC | Must | Should | 역할 |
|------|:----:|:------:|-----|
| **SPEC-XPE-REG** | 3 | 6+ | 규제 마스터 |
| **SPEC-XPE-SEC** | 4 | 5 | 사이버보안 마스터 |
| **SPEC-XPE-IOP** | 2 | 5 | 상호운용성 마스터 |
| **SPEC-XPE-OPS** | 1 | 5 | 운영·관측성 마스터 |
| **SPEC-XPE-P3-AI** | 0 (전체 Should) | 8 | AI 모듈 v1.0 (조건부 승격) |

## 변경 파일 (11)

### Commit 1: 서베이 + MASTER v3 (6)
- `.moai/project/trend-survey-2026.md` (신규, v1.1)
- `.moai/project/product.md` (v2.0 → v2.1)
- `.moai/project/tech.md` (v1.0 → v2.0, SBOM/SLSA/OTEL 추가)
- `.moai/specs/SPEC-XPE-MASTER/v3-upgrade.md` (신규, v2.0 addendum)
- `.moai/specs/SPEC-XPE-MASTER/score-improvement-plan-v3.md` (신규, v3.1)
- `.moai/specs/SPEC-XPE-MASTER/sprint-execution-roadmap-v3.md` (신규, v3.1)

### Commit 2: 신규 SPEC 5종 (5)
- `.moai/specs/SPEC-XPE-REG/spec.md` (신규, v1.1)
- `.moai/specs/SPEC-XPE-SEC/spec.md` (신규, v1.1)
- `.moai/specs/SPEC-XPE-IOP/spec.md` (신규, v1.1)
- `.moai/specs/SPEC-XPE-OPS/spec.md` (신규, v1.1)
- `.moai/specs/SPEC-XPE-P3-AI/spec.md` (신규, v1.1)

## 검토 포인트

- [ ] v1.1 재분류 원칙(법률/시장 블로커/IEC 62304 강제)이 올바르게 적용되었는가
- [ ] Must 12 항목이 실제 출시 블로커를 모두 포함하는가
- [ ] Should 강등 15 항목이 적절한가 (ISO 42001/IEC 81001-5-1 자발적 분류 타당성)
- [ ] 조건부 Must 승격 규칙이 Phase 전환 시점 명확한가
- [ ] 신규 5 SPEC의 EARS 요구사항이 SPEC-XPE-MASTER v3와 정합한가
- [ ] trend-survey-2026.md의 WebSearch 인용 URL이 모두 유효한가

## 주의사항

- 이 PR은 **문서 전용** 변경 (코드 변경 없음)
- 기존 SPEC-XPE-P0/P1A/P2-ADV는 그대로 유지됨
- 기존 SPEC-XPE-MASTER/spec.md (v2.0.0)는 변경 없음, `v3-upgrade.md` addendum으로 확장
- 기존 Phase 0/1a WIP (`modules/common/*`, `modules/enhance_advanced/*`)는 이 PR에 포함되지 않음
- `.claude/settings.json` 등 민감 가능 파일 제외

## Test plan

문서 전용 PR이므로 자동화 테스트 없음. 수동 검토 체크리스트:
- [ ] `.moai/project/trend-survey-2026.md` 렌더링 확인 (55+ 항목 매트릭스)
- [ ] `SPEC-XPE-MASTER/v3-upgrade.md` 과 v2.0.0 spec.md 병행 가독성 확인
- [ ] 각 신규 SPEC의 EARS 요구사항 수 (REQ 카운트) 확인
- [ ] `product.md`, `tech.md` 변경분이 기존 컨벤션과 일관적인지 확인
- [ ] Legal/Regulatory Affairs 팀 검토 권장 (Must 12 분류 적정성)

🗿 MoAI <email@mo.ai.kr>