### PR TITLE
fix(pre): P1A 심각 결함 D1/D4 수정 + REQ-P1A-066 에러 경로 테스트 (#68 #70 #73)

### DIFF
--- a/modules/preprocess/CMakeLists.txt
+++ b/modules/preprocess/CMakeLists.txt
@@ -163,6 +163,8 @@ if(_XPE_BUILD_TESTS)
         tests/test_verify_metrics.cpp
         # SWU-1.12: Calibration Mode Selection tests (FUNC-031~033)
         tests/test_calib_mode.cpp
+        # REQ-P1A-066: OOM guard / IO failure / SHA-256 mismatch / Ghost multi-handle race
+        tests/test_req_p1a_066.cpp
     )
 
     add_executable(xpe_preprocess_tests

--- a/modules/preprocess/src/defect_correct.cpp
+++ b/modules/preprocess/src/defect_correct.cpp
@@ -11,6 +11,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <limits>
 #include <vector>
 #include <algorithm>
 #include <queue>
@@ -28,7 +29,7 @@ ClusterInfo analyzeCluster(const uint8_t* defectMask, uint32_t width, uint32_t h
                            uint32_t startX, uint32_t startY)
 {
     ClusterInfo info;
-    std::vector<bool> visited(width * height, false);
+    std::vector<bool> visited(static_cast<size_t>(width) * height, false);
     std::queue<uint32_t> q;
 
     uint32_t startIdx = startY * width + startX;
@@ -93,7 +94,7 @@ float median_filter_cluster(const float* pixels, const uint8_t* defectMask,
     }
 
     if (values.empty()) {
-        return pixels[static_cast<size_t>(y) * width + x];
+        return 0.0f;
     }
 
     std::sort(values.begin(), values.end());
@@ -115,6 +116,7 @@ extern "C" XPE_API XpeErrorCode xpe_defect_correct(
     if (!input->data || !output->data) return XPE_ERR_INVALID_INPUT;
     if (input->format != XPE_PIXEL_FLOAT32) return XPE_ERR_UNSUPPORTED_FORMAT;
     if (input->width == 0 || input->height == 0) return XPE_ERR_INVALID_INPUT;
+    if (input->width > std::numeric_limits<size_t>::max() / input->height) return XPE_ERR_INVALID_INPUT;
     if (output->width  != input->width ||
         output->height != input->height) return XPE_ERR_BUFFER_TOO_SMALL;
 

--- a/modules/preprocess/src/gain_correct.cpp
+++ b/modules/preprocess/src/gain_correct.cpp
@@ -252,6 +252,7 @@ extern "C" XPE_API XpeErrorCode xpe_gain_correct(
     if (!input->data || !output->data) return XPE_ERR_INVALID_INPUT;
     if (input->format != XPE_PIXEL_UINT16) return XPE_ERR_UNSUPPORTED_FORMAT;
     if (input->width == 0 || input->height == 0) return XPE_ERR_INVALID_INPUT;
+    if (input->width > std::numeric_limits<size_t>::max() / input->height) return XPE_ERR_INVALID_INPUT;
     if (output->width  != input->width ||
         output->height != input->height) return XPE_ERR_BUFFER_TOO_SMALL;
 
@@ -259,34 +260,38 @@ extern "C" XPE_API XpeErrorCode xpe_gain_correct(
     if (n > std::numeric_limits<size_t>::max() / sizeof(float)) return XPE_ERR_INVALID_INPUT;
     if (output->dataSize < n * sizeof(float)) return XPE_ERR_BUFFER_TOO_SMALL;
 
-    const uint16_t* src     = static_cast<const uint16_t*>(input->data);
-    float*          dst     = static_cast<float*>(output->data);
-    std::vector<float> gainmap;
+    const uint16_t* src = static_cast<const uint16_t*>(input->data);
+    float*          dst = static_cast<float*>(output->data);
 
-    {
-        std::lock_guard<std::mutex> lock(g_calib_mutex);
-        if (!g_calib.gain_map) return XPE_ERR_NOT_INITIALIZED;
-        if (g_calib.gain_width  != input->width ||
-            g_calib.gain_height != input->height) return XPE_ERR_BUFFER_TOO_SMALL;
-        gainmap.assign(g_calib.gain_map.get(), g_calib.gain_map.get() + n);
+    try {
+        std::vector<float> gainmap;
+        {
+            std::lock_guard<std::mutex> lock(g_calib_mutex);
+            if (!g_calib.gain_map) return XPE_ERR_NOT_INITIALIZED;
+            if (g_calib.gain_width  != input->width ||
+                g_calib.gain_height != input->height) return XPE_ERR_BUFFER_TOO_SMALL;
+            gainmap.assign(g_calib.gain_map.get(), g_calib.gain_map.get() + n);
+        }
+
+        // Validate gain map and precompute reciprocals
+        std::vector<float> reciprocal(n);
+        for (size_t i = 0; i < n; ++i) {
+            if (!is_valid_gain(gainmap[i])) return XPE_ERR_CONFIG_INVALID;
+            reciprocal[i] = 1.0f / gainmap[i];
+        }
+
+        // Apply: AVX2 when available, scalar fallback
+        if (xpe_gain_has_avx2())
+            apply_gain_avx2(src, reciprocal.data(), dst, input->width, input->height);
+        else
+            apply_gain_correction_scalar(src, reciprocal.data(), dst, input->width, input->height);
+
+        output->format        = XPE_PIXEL_FLOAT32;
+        output->bitsAllocated = 32u;
+        output->bitsStored    = 32u;
+        output->dataSize      = n * sizeof(float);
+        return XPE_OK;
+    } catch (const std::bad_alloc&) {
+        return XPE_ERR_OUT_OF_MEMORY;
     }
-
-    // Validate gain map and precompute reciprocals
-    std::vector<float> reciprocal(n);
-    for (size_t i = 0; i < n; ++i) {
-        if (!is_valid_gain(gainmap[i])) return XPE_ERR_CONFIG_INVALID;
-        reciprocal[i] = 1.0f / gainmap[i];
-    }
-
-    // Apply: AVX2 when available, scalar fallback
-    if (xpe_gain_has_avx2())
-        apply_gain_avx2(src, reciprocal.data(), dst, input->width, input->height);
-    else
-        apply_gain_correction_scalar(src, reciprocal.data(), dst, input->width, input->height);
-
-    output->format        = XPE_PIXEL_FLOAT32;
-    output->bitsAllocated = 32u;
-    output->bitsStored    = 32u;
-    output->dataSize      = n * sizeof(float);
-    return XPE_OK;
 }

--- a/modules/preprocess/src/offset_correct.cpp
+++ b/modules/preprocess/src/offset_correct.cpp
@@ -292,6 +292,7 @@ extern "C" XPE_API XpeErrorCode xpe_offset_correct(
     if (!input->data || !output->data) return XPE_ERR_INVALID_INPUT;
     if (input->format != XPE_PIXEL_UINT16) return XPE_ERR_UNSUPPORTED_FORMAT;
     if (input->width == 0 || input->height == 0) return XPE_ERR_INVALID_INPUT;
+    if (input->width > std::numeric_limits<size_t>::max() / input->height) return XPE_ERR_INVALID_INPUT;
     if (output->width  != input->width ||
         output->height != input->height) return XPE_ERR_BUFFER_TOO_SMALL;
 

--- a/modules/preprocess/tests/test_req_p1a_066.cpp
+++ b/modules/preprocess/tests/test_req_p1a_066.cpp
@@ -1,0 +1,191 @@
+/**
+ * @file test_req_p1a_066.cpp
+ * @brief REQ-P1A-066: 4 error path unit tests (IEC 62304 Class B)
+ *
+ *  T1 – OOM guard:       xpe_gain_correct rejects UINT32_MAX×UINT32_MAX dims before
+ *                        any allocation (n > SIZE_MAX/sizeof(float) guard).
+ *  T2 – IO failure:      xpe_calib_load_offset on a directory returns IO_FAILED.
+ *  T3 – SHA-256 corrupt: xcal file with zeroed sha256 returns CONFIG_INVALID.
+ *  T4 – Ghost multi-hdl: 4 threads each with own handle run concurrently, no crash.
+ *
+ * SPEC: SPEC-XPE-P1A v1.2.0  IEC 62304 Class B
+ */
+
+#include <gtest/gtest.h>
+#include "xpe/preprocess_api.h"
+#include "xpe/common/xpe_types.h"
+#include "xpe/common/xpe_error.h"
+#include "xpe/preprocess/xcal_format.h"
+
+#include <vector>
+#include <cstring>
+#include <cstdint>
+#include <limits>
+#include <fstream>
+#include <filesystem>
+#include <thread>
+#include <atomic>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+/* ============================================================================
+ * T1: OOM guard — SIZE_MAX overflow protection in xpe_gain_correct
+ * REQ-P1A-066 D1
+ * ============================================================================ */
+
+// UINT32_MAX × UINT32_MAX yields n ≈ 1.844e19 which exceeds SIZE_MAX/sizeof(float).
+// The guard at "n > SIZE_MAX / sizeof(float)" must fire and return INVALID_INPUT
+// before any heap allocation is attempted.
+TEST(P1A066, T1_GainCorrect_HugeDimension_RejectsBeforeAllocation) {
+    uint16_t src_stub = 0;
+    float    dst_stub = 0.0f;
+
+    XpeImageBuffer input{};
+    input.data          = &src_stub;
+    input.format        = XPE_PIXEL_UINT16;
+    input.width         = std::numeric_limits<uint32_t>::max();
+    input.height        = std::numeric_limits<uint32_t>::max();
+    input.bitsAllocated = 16;
+    input.bitsStored    = 16;
+    input.dataSize      = 1; // won't reach dataSize check
+
+    XpeImageBuffer output{};
+    output.data         = &dst_stub;
+    output.width        = input.width;
+    output.height       = input.height;
+    output.dataSize     = std::numeric_limits<size_t>::max();
+
+    XpeImageMetadata meta{};
+
+    EXPECT_EQ(XPE_ERR_INVALID_INPUT,
+              xpe_gain_correct(&input, &output, &meta));
+}
+
+/* ============================================================================
+ * T2: IO failure — directory path treated as file fails to open
+ * REQ-P1A-066 D2
+ * ============================================================================ */
+
+class P1A066IoTest : public ::testing::Test {
+protected:
+    fs::path tmpPath;
+
+    void SetUp() override {
+        tmpPath = fs::temp_directory_path() / "xpe_p1a066_dir.xcal";
+        fs::remove_all(tmpPath); // ensure clean start
+    }
+
+    void TearDown() override {
+        fs::remove_all(tmpPath);
+    }
+};
+
+// On Windows, std::ifstream cannot open a directory without FILE_FLAG_BACKUP_SEMANTICS,
+// so is_open() returns false → read_xcal_file returns XPE_ERR_IO_FAILED.
+TEST_F(P1A066IoTest, T2_LoadOffset_DirectoryPath_ReturnsIoFailed) {
+    fs::create_directory(tmpPath);
+    EXPECT_EQ(XPE_ERR_IO_FAILED,
+              xpe_calib_load_offset(tmpPath.string().c_str()));
+}
+
+/* ============================================================================
+ * T3: SHA-256 mismatch — corrupted xcal body returns CONFIG_INVALID
+ * REQ-P1A-066 D3
+ * ============================================================================ */
+
+static void write_xcal_wrong_sha256(const fs::path& path) {
+    // Build a syntactically valid 4×4 OFFSET header, but leave sha256 zeroed.
+    // compute_sha256_two_parts() will compute the real hash of the payload and
+    // find it differs from the zeroed sha256 field → XPE_ERR_CONFIG_INVALID.
+    XCalFileHeader hdr{};
+    std::memcpy(hdr.magic, XCAL_MAGIC, 4);
+    hdr.version         = XCAL_VERSION;
+    hdr.type            = static_cast<uint32_t>(XCAL_TYPE_OFFSET);
+    hdr.pixel_format    = static_cast<uint32_t>(XCAL_FMT_FLOAT32);
+    hdr.width           = 4;
+    hdr.height          = 4;
+    hdr.created_epoch_ms = 0;
+    hdr.expiry_epoch_ms  = 0; // never expires
+    std::memset(hdr.session_id, 0, sizeof(hdr.session_id));
+    hdr.config_json_len = 0;
+    hdr.payload_len     = static_cast<uint64_t>(4u * 4u * sizeof(float)); // 64
+    std::memset(hdr.sha256, 0, sizeof(hdr.sha256)); // intentionally wrong
+
+    std::vector<float> payload(4u * 4u, 1.0f);
+
+    std::ofstream f(path, std::ios::binary);
+    f.write(reinterpret_cast<const char*>(&hdr),
+            static_cast<std::streamsize>(sizeof(hdr)));
+    f.write(reinterpret_cast<const char*>(payload.data()),
+            static_cast<std::streamsize>(payload.size() * sizeof(float)));
+}
+
+TEST(P1A066, T3_LoadOffset_WrongSha256_ReturnsConfigInvalid) {
+    fs::path tmp = fs::temp_directory_path() / "xpe_p1a066_badsha.xcal";
+    write_xcal_wrong_sha256(tmp);
+
+    XpeErrorCode rc = xpe_calib_load_offset(tmp.string().c_str());
+    fs::remove(tmp);
+
+    EXPECT_EQ(XPE_ERR_CONFIG_INVALID, rc);
+}
+
+/* ============================================================================
+ * T4: Ghost multi-handle race — 4 independent handles on 4 threads
+ * REQ-P1A-066 D4
+ *
+ * The ghost handle is NOT thread-safe for sharing (no internal mutex).
+ * This test verifies that multiple handles owned by different threads can
+ * operate concurrently without corrupting shared global state or crashing.
+ * ============================================================================ */
+
+TEST(P1A066, T4_GhostCorrect_MultiHandle_ConcurrentNoError) {
+    static constexpr uint32_t W = 16;
+    static constexpr uint32_t H = 16;
+    static constexpr int      THREADS    = 4;
+    static constexpr int      ITERATIONS = 50;
+
+    std::atomic<int> errors{0};
+
+    std::vector<std::thread> threads;
+    threads.reserve(THREADS);
+
+    for (int t = 0; t < THREADS; ++t) {
+        threads.emplace_back([t, &errors]() {
+            void* handle = nullptr;
+            if (xpe_ghost_create(W, H, nullptr, &handle) != XPE_OK) {
+                ++errors;
+                return;
+            }
+
+            std::vector<float> px(static_cast<size_t>(W) * H, 500.0f);
+            XpeImageBuffer img{};
+            img.data          = px.data();
+            img.width         = W;
+            img.height        = H;
+            img.bitsAllocated = 32;
+            img.bitsStored    = 32;
+            img.format        = XPE_PIXEL_FLOAT32;
+            img.dataSize      = px.size() * sizeof(float);
+
+            XpeImageMetadata meta{};
+            for (int i = 0; i < ITERATIONS; ++i) {
+                meta.acquisitionTime = static_cast<uint64_t>(t * ITERATIONS + i);
+                if (xpe_ghost_correct(handle, &img, &meta) != XPE_OK) {
+                    ++errors;
+                }
+            }
+
+            xpe_ghost_destroy(handle);
+        });
+    }
+
+    for (auto& th : threads) th.join();
+
+    EXPECT_EQ(0, errors.load())
+        << "All " << THREADS << " independent ghost handles should correct without error";
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- **D4 (SIZE_MAX overflow guard)**: `offset_correct.cpp`, `gain_correct.cpp`, `defect_correct.cpp`에 `width > SIZE_MAX/height` 오버플로우 가드 추가 — 정수 오버플로우로 인한 under-allocation 방지
- **D1 (bad_alloc 보호)**: `gain_correct.cpp`의 vector 할당 구간을 `try-catch(bad_alloc)` 로 감싸 `XPE_ERR_OUT_OF_MEMORY` 반환
- **#70 fallback 수정**: `median_filter_cluster` 전체 이웃이 결함일 때 원래 픽셀 반환 대신 `0.0f` 반환으로 변경 (참조 데이터 손상 방지)
- **REQ-P1A-066**: 4종 에러 경로 단위 테스트 추가
  - T1: UINT32_MAX×UINT32_MAX 차원 → SIZE_MAX guard → `INVALID_INPUT`
  - T2: 디렉터리를 xcal 파일로 열기 → `IO_FAILED`
  - T3: SHA-256 zeroed xcal → `CONFIG_INVALID`
  - T4: 4스레드 독립 ghost handle 병렬 → 충돌 없음

## Test plan

- [ ] `test_req_p1a_066.cpp` T1~T4 모두 pass 확인
- [ ] `test_defect_correct_avx2_parity.cpp` 회귀 없음 확인
- [ ] `test_calibration_manager.cpp` 기존 테스트 통과 확인
- [ ] `test_ghost_correct.cpp` 기존 테스트 통과 확인

Closes #68 #70 #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)