### PR TITLE
[GUI-C] AI IPC Bridge UI C5/C6 구현

### DIFF
--- a/clients/ImageProcTest.IntegrationTests/AiBridgeUi/AiBridgeStatusComputerTests.cs
+++ b/clients/ImageProcTest.IntegrationTests/AiBridgeUi/AiBridgeStatusComputerTests.cs
@@ -1,0 +1,151 @@
+// SPEC: SPEC-XPE-P3-AI (Issue #83) - AI IPC Bridge UI C5/C6 graceful degraded mode.
+// These tests pin the contract of AiBridgeStatusComputer, the pure helper that
+// the WPF MainWindow uses to derive AI panel state. They run in the headless
+// IntegrationTests project (net8.0, no WPF) via linked source files.
+using System.Collections.Generic;
+using ImageProcTest;
+using Xunit;
+
+namespace ImageProcTest.IntegrationTests.AiBridgeUi
+{
+    public sealed class AiBridgeStatusComputerTests
+    {
+        [Fact]
+        public void Compute_NullReadiness_ReturnsNotConnectedSnapshot()
+        {
+            var snapshot = AiBridgeStatusComputer.Compute(null);
+
+            Assert.Equal(AiBridgeConnectionStatus.NotConnected, snapshot.Status);
+            Assert.Equal("AI Engine: Not Connected", snapshot.HeaderText);
+            Assert.Contains("xpe_ai.dll not detected", snapshot.DetailText);
+            Assert.Contains("No AI analysis available", snapshot.ResultsText);
+            Assert.False(snapshot.ConnectButtonEnabled);
+            Assert.False(snapshot.ConnectionInputsEnabled);
+            Assert.Equal(AiBridgeStatusComputer.Phase3Tooltip, snapshot.Tooltip);
+        }
+
+        [Fact]
+        public void Compute_EmptyReadiness_ReturnsNotConnectedSnapshot()
+        {
+            var snapshot = AiBridgeStatusComputer.Compute(new List<ModuleReadinessSnapshot>());
+
+            Assert.Equal(AiBridgeConnectionStatus.NotConnected, snapshot.Status);
+            Assert.Equal("AI Engine: Not Connected", snapshot.HeaderText);
+        }
+
+        [Fact]
+        public void Compute_ReadinessWithoutAiModule_ReturnsNotConnected()
+        {
+            var modules = new List<ModuleReadinessSnapshot>
+            {
+                new("xpe_common", "R3", "Ready", "evidence", "next", true)
+            };
+
+            var snapshot = AiBridgeStatusComputer.Compute(modules);
+
+            Assert.Equal(AiBridgeConnectionStatus.NotConnected, snapshot.Status);
+            Assert.False(snapshot.ConnectButtonEnabled);
+        }
+
+        [Fact]
+        public void Compute_AiModuleR0_ReturnsNotConnected()
+        {
+            // R0 = not ready / DLL absent. UI must not even allow Connect.
+            var modules = new List<ModuleReadinessSnapshot>
+            {
+                new("xpe_ai", "R0", "Not ready", "no evidence", "deploy worker", false)
+            };
+
+            var snapshot = AiBridgeStatusComputer.Compute(modules);
+
+            Assert.Equal(AiBridgeConnectionStatus.NotConnected, snapshot.Status);
+            Assert.False(snapshot.ConnectButtonEnabled);
+            Assert.False(snapshot.ConnectionInputsEnabled);
+        }
+
+        [Fact]
+        public void Compute_AiModuleR1WithoutConnectAttempt_ReturnsAvailable()
+        {
+            var modules = new List<ModuleReadinessSnapshot>
+            {
+                new("xpe_ai", "R1", "Binary present", "version=0.0.1", "next", false)
+            };
+
+            var snapshot = AiBridgeStatusComputer.Compute(modules);
+
+            Assert.Equal(AiBridgeConnectionStatus.Available, snapshot.Status);
+            Assert.True(snapshot.ConnectButtonEnabled);
+            Assert.True(snapshot.ConnectionInputsEnabled);
+            Assert.Contains("Connect", snapshot.DetailText);
+        }
+
+        [Fact]
+        public void Compute_AiModuleR2UserRequestedConnect_ReturnsConnecting()
+        {
+            var modules = new List<ModuleReadinessSnapshot>
+            {
+                new("xpe_ai", "R2", "ABI smoke", "evidence", "next", false)
+            };
+
+            var snapshot = AiBridgeStatusComputer.Compute(modules, userRequestedConnect: true);
+
+            Assert.Equal(AiBridgeConnectionStatus.Connecting, snapshot.Status);
+            Assert.False(snapshot.ConnectButtonEnabled);
+            Assert.True(snapshot.DisconnectButtonEnabled);
+            Assert.Contains("Connecting", snapshot.HeaderText);
+        }
+
+        [Fact]
+        public void Compute_AiModuleR3Enabled_ReturnsConnected()
+        {
+            var modules = new List<ModuleReadinessSnapshot>
+            {
+                new("xpe_ai", "R3", "Worker heartbeat OK", "evidence", "ready", true)
+            };
+
+            var snapshot = AiBridgeStatusComputer.Compute(modules);
+
+            Assert.Equal(AiBridgeConnectionStatus.Connected, snapshot.Status);
+            Assert.Equal("AI Engine: Connected", snapshot.HeaderText);
+            Assert.False(snapshot.ConnectButtonEnabled);
+            Assert.True(snapshot.DisconnectButtonEnabled);
+        }
+
+        [Fact]
+        public void Compute_LastErrorMessage_OverridesToErrorState()
+        {
+            var modules = new List<ModuleReadinessSnapshot>
+            {
+                new("xpe_ai", "R0", "Not ready", "no evidence", "deploy worker", false)
+            };
+
+            var snapshot = AiBridgeStatusComputer.Compute(
+                modules,
+                userRequestedConnect: true,
+                lastErrorMessage: "xpe_ai.dll absent (Phase 3 not yet deployed)");
+
+            Assert.Equal(AiBridgeConnectionStatus.Error, snapshot.Status);
+            Assert.Contains("Connection Error", snapshot.HeaderText);
+            Assert.Contains("xpe_ai.dll absent", snapshot.DetailText);
+            Assert.True(snapshot.ConnectButtonEnabled);
+            Assert.Contains("No AI analysis available", snapshot.ResultsText);
+        }
+
+        [Fact]
+        public void Compute_NeverThrowsOnUnusualReadinessShapes()
+        {
+            // Defensive: empty strings, weird casing, null collection - none should throw.
+            var modules = new List<ModuleReadinessSnapshot>
+            {
+                new("XPE_AI", "", "", "", "", false),
+                new("Xpe_Ai", "Rfoo", "weird", "weird", "weird", false)
+            };
+
+            var snapshot = AiBridgeStatusComputer.Compute(modules);
+
+            Assert.NotNull(snapshot);
+            Assert.False(string.IsNullOrEmpty(snapshot.HeaderText));
+            Assert.False(string.IsNullOrEmpty(snapshot.ResultsText));
+        }
+    }
+}

--- a/clients/ImageProcTest.IntegrationTests/ImageProcTest.IntegrationTests.csproj
+++ b/clients/ImageProcTest.IntegrationTests/ImageProcTest.IntegrationTests.csproj
@@ -36,6 +36,18 @@
   </ItemGroup>
 
   <!--
+    Linked source files for Phase 3 AI IPC Bridge UI logic (SPEC-XPE-P3-AI / Issue #83).
+    These files have no WPF dependencies so they compile cleanly in this net8.0 test project.
+    Tests live under AiBridgeUi/ and exercise the pure status-computer contract.
+  -->
+  <ItemGroup>
+    <Compile Include="..\ImageProcTest\Models\ModuleReadinessSnapshot.cs" Link="AiBridgeUi\Linked\ModuleReadinessSnapshot.cs" />
+    <Compile Include="..\ImageProcTest\Models\AiBridgeConnectionStatus.cs" Link="AiBridgeUi\Linked\AiBridgeConnectionStatus.cs" />
+    <Compile Include="..\ImageProcTest\Models\AiBridgePanelSnapshot.cs" Link="AiBridgeUi\Linked\AiBridgePanelSnapshot.cs" />
+    <Compile Include="..\ImageProcTest\Services\AiBridgeStatusComputer.cs" Link="AiBridgeUi\Linked\AiBridgeStatusComputer.cs" />
+  </ItemGroup>
+
+  <!--
     DLL staging: copy xpe_common.dll from build output to test output directory.
     Falls back gracefully if the build directory does not exist (CI prerequisite).
   -->

--- a/clients/ImageProcTest/MainWindow.xaml
+++ b/clients/ImageProcTest/MainWindow.xaml
@@ -84,6 +84,10 @@
                           Click="MenuShowDiagnostics_Click"
                           AutomationProperties.AutomationId="XPE_Menu_View_ShowDiagnostics_MenuItem"
                           AutomationProperties.Name="Show diagnostics tab"/>
+                <MenuItem Header="_AI Module"
+                          Click="MenuShowAiModule_Click"
+                          AutomationProperties.AutomationId="XPE_Menu_View_ShowAiModule_MenuItem"
+                          AutomationProperties.Name="Show AI module tab"/>
                 <Separator/>
                 <MenuItem Header="Zoom _Fit"
                           Click="MenuZoomFit_Click"
@@ -938,6 +942,203 @@
                                 <DataGridTextColumn Header="Path" Binding="{Binding Path}" Width="*" ElementStyle="{StaticResource WrappingCellTextBlock}"/>
                             </DataGrid.Columns>
                         </DataGrid>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- ===== AI MODULE TAB (C5/C6 - Phase 3 graceful degraded mode) ===== -->
+            <TabItem Header="AI Module"
+                     AutomationProperties.AutomationId="XPE_Tab_AiModule"
+                     AutomationProperties.Name="AI module tab">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="16">
+                        <TextBlock Text="AI IPC Bridge"
+                                   FontSize="18"
+                                   FontWeight="SemiBold"
+                                   Margin="0,0,0,4"/>
+                        <TextBlock Text="Phase 3 AI module surface. xpe_ai.dll is not yet implemented; this panel runs in graceful degraded mode and never blocks deterministic preprocess/enhance pipelines."
+                                   FontSize="12"
+                                   Foreground="#FF57606A"
+                                   TextWrapping="Wrap"
+                                   Margin="0,0,0,12"/>
+
+                        <!-- C5: AI IPC Bridge connection panel -->
+                        <Border BorderBrush="#FFD0D7DE"
+                                BorderThickness="1"
+                                CornerRadius="4"
+                                Padding="12"
+                                Margin="0,0,0,12"
+                                AutomationProperties.AutomationId="XPE_AiModule_ConnectionPanel">
+                            <StackPanel>
+                                <TextBlock Text="Connection (C5)"
+                                           FontSize="14"
+                                           FontWeight="SemiBold"
+                                           Margin="0,0,0,6"/>
+                                <TextBlock x:Name="AiBridgeStatusHeaderText"
+                                           AutomationProperties.AutomationId="AiBridgeStatusHeaderText"
+                                           AutomationProperties.Name="AI engine connection status"
+                                           Text="AI Engine: Not Connected"
+                                           FontSize="13"
+                                           FontWeight="Bold"
+                                           Margin="0,0,0,4"/>
+                                <TextBlock x:Name="AiBridgeStatusDetailText"
+                                           AutomationProperties.AutomationId="AiBridgeStatusDetailText"
+                                           Text="xpe_ai.dll not detected. Phase 3 AI features remain disabled; deterministic preprocess/enhance pipeline continues unaffected."
+                                           FontSize="12"
+                                           Foreground="#FF57606A"
+                                           TextWrapping="Wrap"
+                                           Margin="0,0,0,8"/>
+
+                                <Grid Margin="0,0,0,8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+                                    <TextBlock Grid.Row="0" Grid.Column="0"
+                                               Text="Worker port"
+                                               VerticalAlignment="Center"
+                                               Margin="0,0,8,4"/>
+                                    <TextBox x:Name="AiBridgePortTextBox"
+                                             AutomationProperties.AutomationId="AiBridgePortTextBox"
+                                             Grid.Row="0" Grid.Column="1"
+                                             Text="51900"
+                                             IsEnabled="False"
+                                             Width="120"
+                                             HorizontalAlignment="Left"
+                                             Margin="0,0,0,4"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="0"
+                                               Text="Timeout (ms)"
+                                               VerticalAlignment="Center"
+                                               Margin="0,0,8,0"/>
+                                    <TextBox x:Name="AiBridgeTimeoutTextBox"
+                                             AutomationProperties.AutomationId="AiBridgeTimeoutTextBox"
+                                             Grid.Row="1" Grid.Column="1"
+                                             Text="5000"
+                                             IsEnabled="False"
+                                             Width="120"
+                                             HorizontalAlignment="Left"/>
+                                </Grid>
+
+                                <StackPanel Orientation="Horizontal">
+                                    <Button x:Name="AiBridgeConnectButton"
+                                            AutomationProperties.AutomationId="AiBridgeConnectButton"
+                                            AutomationProperties.Name="Connect AI engine"
+                                            Content="Connect"
+                                            Width="96"
+                                            Height="28"
+                                            IsEnabled="False"
+                                            ToolTip="Requires xpe_ai.dll - Phase 3 feature (SPEC-XPE-P3-AI)."
+                                            Click="AiBridgeConnectButton_Click"
+                                            Margin="0,0,8,0"/>
+                                    <Button x:Name="AiBridgeDisconnectButton"
+                                            AutomationProperties.AutomationId="AiBridgeDisconnectButton"
+                                            AutomationProperties.Name="Disconnect AI engine"
+                                            Content="Disconnect"
+                                            Width="96"
+                                            Height="28"
+                                            IsEnabled="False"
+                                            Click="AiBridgeDisconnectButton_Click"
+                                            Margin="0,0,8,0"/>
+                                    <Button x:Name="AiBridgeRefreshButton"
+                                            AutomationProperties.AutomationId="AiBridgeRefreshButton"
+                                            AutomationProperties.Name="Refresh AI module readiness"
+                                            Content="Refresh"
+                                            Width="96"
+                                            Height="28"
+                                            Click="AiBridgeRefreshButton_Click"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- C6: AI Inference results panel -->
+                        <Border BorderBrush="#FFD0D7DE"
+                                BorderThickness="1"
+                                CornerRadius="4"
+                                Padding="12"
+                                AutomationProperties.AutomationId="XPE_AiModule_ResultsPanel">
+                            <StackPanel>
+                                <TextBlock Text="Inference Results (C6)"
+                                           FontSize="14"
+                                           FontWeight="SemiBold"
+                                           Margin="0,0,0,6"/>
+                                <TextBlock x:Name="AiBridgeResultsText"
+                                           AutomationProperties.AutomationId="AiBridgeResultsText"
+                                           AutomationProperties.Name="AI inference results"
+                                           Text="No AI analysis available - inference score and anomaly map will appear here once the AI worker connects."
+                                           FontSize="12"
+                                           Foreground="#FF57606A"
+                                           TextWrapping="Wrap"
+                                           Margin="0,0,0,8"/>
+
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Border Grid.Column="0"
+                                            BorderBrush="#FFE5E9EE"
+                                            BorderThickness="1"
+                                            Background="#FFFAFBFC"
+                                            CornerRadius="3"
+                                            Padding="10"
+                                            Margin="0,0,4,0"
+                                            AutomationProperties.AutomationId="AiBridgeInferenceScorePlaceholder">
+                                        <StackPanel>
+                                            <TextBlock Text="Inference score"
+                                                       FontSize="12"
+                                                       FontWeight="SemiBold"
+                                                       Margin="0,0,0,4"/>
+                                            <TextBlock x:Name="AiBridgeInferenceScoreText"
+                                                       Text="--"
+                                                       FontSize="18"
+                                                       FontFamily="Consolas"
+                                                       Foreground="#FF57606A"/>
+                                            <TextBlock Text="Populated after first successful inference."
+                                                       FontSize="11"
+                                                       Foreground="#FF8B949E"
+                                                       TextWrapping="Wrap"
+                                                       Margin="0,4,0,0"/>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Grid.Column="1"
+                                            BorderBrush="#FFE5E9EE"
+                                            BorderThickness="1"
+                                            Background="#FFFAFBFC"
+                                            CornerRadius="3"
+                                            Padding="10"
+                                            Margin="4,0,0,0"
+                                            AutomationProperties.AutomationId="AiBridgeAnomalyMapPlaceholder">
+                                        <StackPanel>
+                                            <TextBlock Text="Anomaly map"
+                                                       FontSize="12"
+                                                       FontWeight="SemiBold"
+                                                       Margin="0,0,0,4"/>
+                                            <Border BorderBrush="#FFE5E9EE"
+                                                    BorderThickness="1"
+                                                    Background="#FFEFF1F4"
+                                                    Height="120"
+                                                    CornerRadius="2">
+                                                <TextBlock x:Name="AiBridgeAnomalyMapPlaceholderText"
+                                                           Text="No anomaly map"
+                                                           Foreground="#FF8B949E"
+                                                           FontSize="12"
+                                                           HorizontalAlignment="Center"
+                                                           VerticalAlignment="Center"/>
+                                            </Border>
+                                            <TextBlock Text="Future: heatmap overlay rendering."
+                                                       FontSize="11"
+                                                       Foreground="#FF8B949E"
+                                                       TextWrapping="Wrap"
+                                                       Margin="0,4,0,0"/>
+                                        </StackPanel>
+                                    </Border>
+                                </Grid>
+                            </StackPanel>
+                        </Border>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/clients/ImageProcTest/MainWindow.xaml.cs
+++ b/clients/ImageProcTest/MainWindow.xaml.cs
@@ -46,6 +46,8 @@ namespace ImageProcTest
         private UserEvaluationSnapshot? lastUserEvaluation;
         private FixtureCaseInfo? currentCalibrationContext;
         private string? currentCalibrationFolderPath;
+        private bool aiBridgeConnectRequested;
+        private string? aiBridgeLastError;
         private readonly EvaluationContextService evaluationContextService = new();
         private readonly ModuleReadinessViewModel moduleReadinessViewModel = new();
         private ActiveEvaluationContext? activeEvaluationContext;
@@ -138,6 +140,11 @@ namespace ImageProcTest
         private void MenuShowDiagnostics_Click(object sender, RoutedEventArgs e)
         {
             SelectTab("Diagnostics");
+        }
+
+        private void MenuShowAiModule_Click(object sender, RoutedEventArgs e)
+        {
+            SelectTab("AI Module");
         }
 
         private void MenuZoomFit_Click(object sender, RoutedEventArgs e)
@@ -1671,6 +1678,7 @@ namespace ImageProcTest
             UpdateGsvgWorkflowStatus();
             UpdateAdvancedWorkflowStatus();
             UpdateAiWorkflowStatus();
+            UpdateAiBridgePanel();
             UpdateWorkflowRunState();
         }
 
@@ -2000,6 +2008,70 @@ namespace ImageProcTest
                 $"AI UI: Phase 3 C5/C6 rows={rowCount}; selected={selected}; " +
                 $"{ai.Level} {ai.Status}; execution={ai.ExecutionState}; " +
                 $"skip={ai.DegradedMode}; next={ai.NextAction}";
+        }
+
+        // @MX:NOTE: Drives the AI Module tab (C5 connection + C6 results placeholder) every refresh.
+        // @MX:REASON: xpe_ai.dll is a Phase 3 dependency that may be absent in current builds; the UI
+        // must remain functional in degraded mode without throwing or blocking the main pipeline.
+        private void UpdateAiBridgePanel()
+        {
+            if (AiBridgeStatusHeaderText is null)
+            {
+                return;
+            }
+
+            var snapshot = AiBridgeStatusComputer.Compute(
+                currentModuleReadiness,
+                aiBridgeConnectRequested,
+                aiBridgeLastError);
+
+            AiBridgeStatusHeaderText.Text = snapshot.HeaderText;
+            AiBridgeStatusDetailText.Text = snapshot.DetailText;
+            AiBridgeResultsText.Text = snapshot.ResultsText;
+            AiBridgeConnectButton.IsEnabled = snapshot.ConnectButtonEnabled;
+            AiBridgeConnectButton.ToolTip = snapshot.Tooltip;
+            AiBridgeDisconnectButton.IsEnabled = snapshot.DisconnectButtonEnabled;
+            AiBridgePortTextBox.IsEnabled = snapshot.ConnectionInputsEnabled;
+            AiBridgeTimeoutTextBox.IsEnabled = snapshot.ConnectionInputsEnabled;
+        }
+
+        private void AiBridgeConnectButton_Click(object sender, RoutedEventArgs e)
+        {
+            aiBridgeLastError = null;
+            aiBridgeConnectRequested = true;
+
+            // @MX:WARN: xpe_ai.dll is a Phase 3 (Should priority) dependency and is not yet built.
+            // @MX:REASON: SPEC-XPE-P3-AI explicitly mandates graceful degradation when the AI worker
+            // is absent. We must surface the failure as a user-visible message rather than throwing.
+            try
+            {
+                if (!IsModuleReadinessAtLeast("xpe_ai", 1))
+                {
+                    aiBridgeLastError = "xpe_ai.dll absent (Phase 3 not yet deployed)";
+                }
+            }
+            catch (Exception ex)
+            {
+                aiBridgeLastError = $"Connect attempt threw: {ex.GetType().Name}";
+            }
+            finally
+            {
+                UpdateAiBridgePanel();
+            }
+        }
+
+        private void AiBridgeDisconnectButton_Click(object sender, RoutedEventArgs e)
+        {
+            aiBridgeConnectRequested = false;
+            aiBridgeLastError = null;
+            UpdateAiBridgePanel();
+        }
+
+        private void AiBridgeRefreshButton_Click(object sender, RoutedEventArgs e)
+        {
+            aiBridgeLastError = null;
+            RefreshModuleReadiness();
+            UpdateEvaluationDashboards();
         }
 
         private void AddReportArtifact(string kind, string path)

--- a/clients/ImageProcTest/Models/AiBridgeConnectionStatus.cs
+++ b/clients/ImageProcTest/Models/AiBridgeConnectionStatus.cs
@@ -1,0 +1,29 @@
+// @MX:NOTE: Pure status enum for AI IPC Bridge UI (C5/C6).
+// @MX:REASON: Decouples UI binding from WPF runtime so logic can be unit-tested
+// without instantiating MainWindow or referencing PresentationFramework.
+// SPEC: SPEC-XPE-P3-AI (Issue #83) — graceful degraded mode when xpe_ai.dll absent.
+namespace ImageProcTest
+{
+    /// <summary>
+    /// Represents the AI IPC Bridge UI panel state.
+    /// All transitions originate from <see cref="AiBridgeStatusComputer"/>
+    /// based on <see cref="ModuleReadinessSnapshot"/>; the UI never invents states locally.
+    /// </summary>
+    internal enum AiBridgeConnectionStatus
+    {
+        /// <summary>xpe_ai.dll absent or readiness probe never executed.</summary>
+        NotConnected,
+
+        /// <summary>xpe_ai readiness reached binary/ABI tier but worker handshake not yet attempted.</summary>
+        Available,
+
+        /// <summary>User initiated connect attempt; awaiting worker heartbeat / IPC response.</summary>
+        Connecting,
+
+        /// <summary>Worker heartbeat OK and adapter smoke passed; inference branches may execute.</summary>
+        Connected,
+
+        /// <summary>Connect attempted but failed (DLL missing, version mismatch, worker timeout, etc.).</summary>
+        Error,
+    }
+}

--- a/clients/ImageProcTest/Models/AiBridgePanelSnapshot.cs
+++ b/clients/ImageProcTest/Models/AiBridgePanelSnapshot.cs
@@ -1,0 +1,19 @@
+// @MX:NOTE: Immutable snapshot bound to the AI Module tab UI (C5 connection + C6 results).
+// @MX:REASON: Single source-of-truth for the AI panel display so a single computation
+// drives both header status and results placeholder, ensuring degraded-mode parity.
+namespace ImageProcTest
+{
+    /// <summary>
+    /// Display-ready snapshot of the AI IPC Bridge UI for one render frame.
+    /// Produced by <see cref="AiBridgeStatusComputer"/>.
+    /// </summary>
+    internal sealed record AiBridgePanelSnapshot(
+        AiBridgeConnectionStatus Status,
+        string HeaderText,
+        string DetailText,
+        string ResultsText,
+        bool ConnectButtonEnabled,
+        bool DisconnectButtonEnabled,
+        bool ConnectionInputsEnabled,
+        string Tooltip);
+}

--- a/clients/ImageProcTest/Services/AiBridgeStatusComputer.cs
+++ b/clients/ImageProcTest/Services/AiBridgeStatusComputer.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ImageProcTest
+{
+    // @MX:ANCHOR: Single function that converts module readiness into AI panel display state.
+    // @MX:REASON: Fan-in >= 3 (MainWindow header bind, AI tab bind, unit tests). Any logic drift
+    // here breaks Phase 3 graceful-degradation contract from SPEC-XPE-P3-AI / Issue #83.
+    /// <summary>
+    /// Pure logic helper that builds an <see cref="AiBridgePanelSnapshot"/> from a
+    /// <see cref="ModuleReadinessSnapshot"/> list. WPF-free so it can be unit-tested
+    /// without WPF dispatcher or window construction.
+    /// </summary>
+    internal static class AiBridgeStatusComputer
+    {
+        internal const string ModuleName = "xpe_ai";
+        internal const string Phase3Tooltip =
+            "Requires xpe_ai.dll - Phase 3 feature (SPEC-XPE-P3-AI).";
+
+        /// <summary>
+        /// Compute the panel snapshot. <paramref name="moduleReadiness"/> may be empty
+        /// (e.g. before readiness probe runs) - we still return a stable NotConnected snapshot.
+        /// <paramref name="userRequestedConnect"/> tracks whether the user clicked Connect since
+        /// the last refresh; this lets the UI show <c>Connecting</c> even when readiness has
+        /// not yet flipped, so the button does not feel unresponsive.
+        /// </summary>
+        public static AiBridgePanelSnapshot Compute(
+            IReadOnlyList<ModuleReadinessSnapshot>? moduleReadiness,
+            bool userRequestedConnect = false,
+            string? lastErrorMessage = null)
+        {
+            var snapshot = FindAiSnapshot(moduleReadiness);
+            var rank = snapshot?.LevelRank ?? 0;
+
+            if (!string.IsNullOrEmpty(lastErrorMessage))
+            {
+                return new AiBridgePanelSnapshot(
+                    Status: AiBridgeConnectionStatus.Error,
+                    HeaderText: "AI Engine: Connection Error",
+                    DetailText: $"Last connect attempt failed: {lastErrorMessage}. Phase 3 worker not yet available; UI remains in degraded mode.",
+                    ResultsText: "No AI analysis available - retry connect or wait for xpe_ai.dll deployment.",
+                    ConnectButtonEnabled: true,
+                    DisconnectButtonEnabled: false,
+                    ConnectionInputsEnabled: true,
+                    Tooltip: Phase3Tooltip);
+            }
+
+            if (snapshot is null || rank < 1)
+            {
+                return new AiBridgePanelSnapshot(
+                    Status: AiBridgeConnectionStatus.NotConnected,
+                    HeaderText: "AI Engine: Not Connected",
+                    DetailText: "xpe_ai.dll not detected. Phase 3 AI features remain disabled; deterministic preprocess/enhance pipeline continues unaffected.",
+                    ResultsText: "No AI analysis available - inference score and anomaly map will appear here once the AI worker connects.",
+                    ConnectButtonEnabled: false,
+                    DisconnectButtonEnabled: false,
+                    ConnectionInputsEnabled: false,
+                    Tooltip: Phase3Tooltip);
+            }
+
+            if (userRequestedConnect && rank < 3)
+            {
+                return new AiBridgePanelSnapshot(
+                    Status: AiBridgeConnectionStatus.Connecting,
+                    HeaderText: "AI Engine: Connecting...",
+                    DetailText: $"xpe_ai readiness {snapshot.Level} {snapshot.Status}; awaiting worker heartbeat and adapter smoke.",
+                    ResultsText: "No AI analysis available - waiting for worker handshake.",
+                    ConnectButtonEnabled: false,
+                    DisconnectButtonEnabled: true,
+                    ConnectionInputsEnabled: false,
+                    Tooltip: Phase3Tooltip);
+            }
+
+            if (snapshot.ProcessingEnabled && rank >= 3)
+            {
+                return new AiBridgePanelSnapshot(
+                    Status: AiBridgeConnectionStatus.Connected,
+                    HeaderText: "AI Engine: Connected",
+                    DetailText: $"xpe_ai {snapshot.Level} {snapshot.Status}. AI assistive branches (body-part, AI collimation, bone suppression, DL denoise, stitching) available as sidecar outputs.",
+                    ResultsText: "AI ready - inference score and anomaly map will populate after the next pipeline run.",
+                    ConnectButtonEnabled: false,
+                    DisconnectButtonEnabled: true,
+                    ConnectionInputsEnabled: false,
+                    Tooltip: Phase3Tooltip);
+            }
+
+            return new AiBridgePanelSnapshot(
+                Status: AiBridgeConnectionStatus.Available,
+                HeaderText: "AI Engine: Available (not connected)",
+                DetailText: $"xpe_ai readiness {snapshot.Level} {snapshot.Status}; click Connect to attempt worker handshake.",
+                ResultsText: "No AI analysis available - press Connect to start the IPC bridge.",
+                ConnectButtonEnabled: true,
+                DisconnectButtonEnabled: false,
+                ConnectionInputsEnabled: true,
+                Tooltip: Phase3Tooltip);
+        }
+
+        private static ModuleReadinessSnapshot? FindAiSnapshot(IReadOnlyList<ModuleReadinessSnapshot>? moduleReadiness)
+        {
+            if (moduleReadiness is null || moduleReadiness.Count == 0)
+            {
+                return null;
+            }
+
+            return moduleReadiness.FirstOrDefault(module =>
+                string.Equals(module.ModuleName, ModuleName, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}


### PR DESCRIPTION
Closes #83

## Summary

Phase 3 AI IPC Bridge UI를 graceful degraded 모드로 추가. `xpe_ai.dll`이 아직 빌드되지 않은 상태에서도 GUI가 충돌 없이 동작하며 결정론적(deterministic) preprocess/enhance 파이프라인을 차단하지 않음.

## C5 - Connection panel

- "AI Module" 탭 신규 추가 (Reports와 Help 사이, View 메뉴 항목 포함)
- 상태 헤더 ("AI Engine: Not Connected" 기본값) + 상세 메시지 영역
- Worker port (51900) / timeout (5000ms) 입력 필드 — readiness R1 미만일 때 비활성
- Connect / Disconnect / Refresh 버튼 + Tooltip ("Requires xpe_ai.dll - Phase 3 feature")
- Connect 클릭 시 readiness 미달이면 **사용자 가시 에러 메시지** 표시 (예외 미발생)

## C6 - Inference results panel

- "No AI analysis available" 기본 placeholder 메시지
- Inference score placeholder (값 "--")
- Anomaly map placeholder (heatmap 영역 자리)
- 미연결 시 placeholder 유지, 다른 UI 기능 절대 차단하지 않음

## 설계 분리

- `AiBridgeStatusComputer` — pure logic, WPF 의존 없음, 단위 테스트 가능
- `AiBridgePanelSnapshot` / `AiBridgeConnectionStatus` — immutable DTO/enum
- `MainWindow`는 snapshot을 바인딩만 수행, 상태 결정 로직은 보유하지 않음

## Test plan

- [x] WPF 프로젝트 빌드 클린 (0 warnings, 0 errors)
- [x] IntegrationTests 89/89 GREEN (80 baseline + 9 신규 AI bridge tests)
- [x] main(5949510) 동기화 완료 — 충돌 없음
- [x] 신규 9개 단위 테스트가 R0/R1/R2/R3 readiness, connect-requested, error, edge-case 모두 검증
- [ ] (수동) GUI 실제 실행하여 AI Module 탭 표시 확인 — Lane C 검증 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)