### PR TITLE
[Post-B] fix: gsvg_version() → xpe_gsvg_version() 접두사 통일

### DIFF
--- a/clients/ImageProcTest/Diagnostics/XpeGsvgReadinessProbe.cs
+++ b/clients/ImageProcTest/Diagnostics/XpeGsvgReadinessProbe.cs
@@ -31,13 +31,13 @@ namespace ImageProcTest
 
                 try
                 {
-                    if (!NativeLibrary.TryGetExport(handle, "gsvg_version", out var symbol))
+                    if (!NativeLibrary.TryGetExport(handle, "xpe_gsvg_version", out var symbol))
                     {
                         return new GsvgHealthResult(
                             "Entry point mismatch",
                             "Unavailable",
                             candidate,
-                            "gsvg.dll exists but gsvg_version export was not found.",
+                            "gsvg.dll exists but xpe_gsvg_version export was not found.",
                             IsVersionReady: false);
                     }
 

--- a/modules/gsvg/include/xpe/gsvg/gsvg_api.h
+++ b/modules/gsvg/include/xpe/gsvg/gsvg_api.h
@@ -39,7 +39,7 @@ extern "C" {
  *
  * @return Null-terminated ASCII string. Lifetime: process. Never NULL.
  */
-XPE_API const char* gsvg_version(void);
+XPE_API const char* xpe_gsvg_version(void);
 
 /**
  * @brief Initialize a GSVG correction handle.

--- a/modules/gsvg/src/gsvg.cpp
+++ b/modules/gsvg/src/gsvg.cpp
@@ -173,7 +173,7 @@ void suppress_grid_row_mean(uint16_t* pixels, int width, int height)
 
 } // namespace
 
-const char* gsvg_version(void)
+const char* xpe_gsvg_version(void)
 {
     return "0.2.0";
 }

--- a/modules/gsvg/tests/test_gsvg_abi_smoke.cpp
+++ b/modules/gsvg/tests/test_gsvg_abi_smoke.cpp
@@ -262,7 +262,7 @@ TEST(GsvgAbiSmoke, RepeatedLifecycleDoesNotLeakOrCrash)
 // ---------------------------------------------------------------------------
 TEST(GsvgAbiSmoke, VersionStringLooksLikeSemver)
 {
-    const char* v = gsvg_version();
+    const char* v = xpe_gsvg_version();
     ASSERT_NE(v, nullptr);
     const std::string s(v);
     ASSERT_FALSE(s.empty());

--- a/modules/gsvg/tests/test_gsvg_benchmark.cpp
+++ b/modules/gsvg/tests/test_gsvg_benchmark.cpp
@@ -12,7 +12,7 @@ TEST(BenchmarkFreeze, BP06_GsvgVersionProbeBaseline)
     const char* version = nullptr;
     auto start = std::chrono::steady_clock::now();
     for (int i = 0; i < kIterations; ++i) {
-        version = gsvg_version();
+        version = xpe_gsvg_version();
     }
     auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now() - start);

--- a/modules/gsvg/tests/test_gsvg_coverage.cpp
+++ b/modules/gsvg/tests/test_gsvg_coverage.cpp
@@ -38,10 +38,10 @@ double row_mean(const std::vector<uint16_t>& image, int y)
 
 TEST(GsvgCoverage, VersionIsStableAndNonEmpty)
 {
-    const char* version = gsvg_version();
+    const char* version = xpe_gsvg_version();
     ASSERT_NE(version, nullptr);
     EXPECT_STRNE(version, "");
-    EXPECT_STREQ(version, gsvg_version());
+    EXPECT_STREQ(version, xpe_gsvg_version());
 }
 
 TEST(GsvgCoverage, GridSuppressionReducesPeriodicRowMeanDeviation)


### PR DESCRIPTION
## 변경 내용
- gsvg_api.h: gsvg_version() → xpe_gsvg_version()
- gsvg.cpp: 구현부 rename
- test_gsvg_abi_smoke.cpp: 호출부 rename
- test_gsvg_coverage.cpp: 호출부 rename (2개)
- test_gsvg_benchmark.cpp: 호출부 rename
- XpeGsvgReadinessProbe.cs: NativeLibrary 심볼 export 이름 동기화 (C# 클라이언트)

## 이슈 해결
Closes #89

## 배경
PR #88 리뷰에서 xpe_gsvg_init/process/shutdown과 접두사 불일치 발견.

## 추가 수정
C++ ABI export 심볼 변경에 따라 C# 클라이언트의 `NativeLibrary.TryGetExport` 호출 심볼명도 동기화 필요. 미수정 시 런타임에 `gsvg.dll exists but gsvg_version export was not found` 오류 발생 가능.

## 잔여 작업 (별도 PR 권장)
- docs/project/api-spec.md, docs/project/sprint-plan.md, docs/post-processing/gsvg/*.md: 문서 동기화 (/moai sync 권장)
- .moai/specs/SPEC-XPE-MASTER/spec.md, .moai/project/api-spec.md: 스펙/프로젝트 문서 동기화